### PR TITLE
VEX-5044: Allow exoplayer to preinit with empty source

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,12 @@ Platforms: Android ExoPlayer
 #### source
 Sets the media source. You can pass an asset loaded via require or an object with a uri.
 
+Setting the source will trigger the player to attempt to load the provided media with all other given props. Please be sure that all props are provided before/at the same time as setting the source.
+
+Rendering the player component with a null source will init the player, and start playing once a source value is provided.
+
+Providing a null source value after loading a previous source will stop playback, and clear out the previous source content.
+
 The docs for this prop are incomplete and will be updated as each option is investigated and tested.
 
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -497,6 +497,7 @@ class ReactExoplayerView extends FrameLayout implements
                     player.prepare(mediaSource, !haveResumePosition, false);
                     playerNeedsSource = false;
 
+                    reLayout(exoPlayerView);
                     eventEmitter.loadStart();
                     loadVideoStarted = true;
                 }
@@ -1045,7 +1046,6 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setSrc(final Uri uri, final String extension, Map<String, String> headers) {
         if (uri != null) {
-            boolean isOriginalSourceNull = srcUri == null;
             boolean isSourceEqual = uri.equals(srcUri);
 
             this.srcUri = uri;
@@ -1055,7 +1055,7 @@ class ReactExoplayerView extends FrameLayout implements
                     DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, bandwidthMeter,
                             this.requestHeaders);
 
-            if (!isOriginalSourceNull && !isSourceEqual) {
+            if (!isSourceEqual) {
                 reloadSource();
             }
         }
@@ -1071,14 +1071,13 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setRawSrc(final Uri uri, final String extension) {
         if (uri != null) {
-            boolean isOriginalSourceNull = srcUri == null;
             boolean isSourceEqual = uri.equals(srcUri);
 
             this.srcUri = uri;
             this.extension = extension;
             this.mediaDataSourceFactory = buildDataSourceFactory(true);
 
-            if (!isOriginalSourceNull && !isSourceEqual) {
+            if (!isSourceEqual) {
                 reloadSource();
             }
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1061,6 +1061,17 @@ class ReactExoplayerView extends FrameLayout implements
         }
     }
 
+    public void clearSrc() {
+        if (srcUri != null) {
+            player.stop(true);
+            this.srcUri = null;
+            this.extension = null;
+            this.requestHeaders = null;
+            this.mediaDataSourceFactory = null;
+            clearResumePosition();
+        }
+    }
+
     public void setProgressUpdateInterval(final float progressUpdateInterval) {
         mProgressUpdateInterval = progressUpdateInterval;
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -147,6 +147,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         Map<String, String> headers = src.hasKey(PROP_SRC_HEADERS) ? toStringMap(src.getMap(PROP_SRC_HEADERS)) : null;
 
         if (TextUtils.isEmpty(uriString)) {
+            videoView.clearSrc();
             return;
         }
 


### PR DESCRIPTION
- Allow player to be init before source is provided, and later update once a source is provided.
- Adds handling for providing a empty source in order to stop playback and clear out any existing content