### PR TITLE
VEX-3245: Buffer Progress UI While Paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+- Add support for `onBufferProgress` on Android for getting buffer data even when the player is paused
+
 - Fix Android AudioFocus bug that could cause player to not respond to play/pause in some instances [#2311](https://github.com/react-native-video/react-native-video/pull/2311)
 
 ### Version 5.1.0-alpha9

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ var styles = StyleSheet.create({
 ### Event props
 * [onAudioBecomingNoisy](#onaudiobecomingnoisy)
 * [onBandwidthUpdate](#onbandwidthupdate)
+* [onBufferProgress](#onbufferprogress)
 * [onEnd](#onend)
 * [onExternalPlaybackChange](#onexternalplaybackchange)
 * [onFullscreenPlayerWillPresent](#onfullscreenplayerwillpresent)
@@ -941,6 +942,18 @@ Example:
 ```
 
 Note: On Android ExoPlayer, you must set the [reportBandwidth](#reportbandwidth) prop to enable this event. This is due to the high volume of events generated.
+
+Platforms: Android ExoPlayer
+
+
+#### onBufferProgress
+Callback function that is called on a set interval which contains the buffer start and end position in ms.
+
+Payload:
+Property | Type | Description
+--- | --- | ---
+start | number | The buffer start (ms)
+end | number | The buffer end (ms)
 
 Platforms: Android ExoPlayer
 

--- a/Video.js
+++ b/Video.js
@@ -233,6 +233,12 @@ export default class Video extends Component {
     }
   };
 
+  _onBufferProgress = (event) => {
+    if (this.props.onBufferProgress) {
+      this.props.onBufferProgress(event.nativeEvent);
+    }
+  };
+
   _onGetLicense = (event) => {
     if (this.props.drm && this.props.drm.getLicense instanceof Function) {
       const data = event.nativeEvent;
@@ -311,6 +317,7 @@ export default class Video extends Component {
       onVideoSeek: this._onSeek,
       onVideoEnd: this._onEnd,
       onVideoBuffer: this._onBuffer,
+      onVideoBufferProgress: this._onBufferProgress,
       onVideoBandwidthUpdate: this._onBandwidthUpdate,
       onTimedMetadata: this._onTimedMetadata,
       onVideoAudioBecomingNoisy: this._onAudioBecomingNoisy,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -81,6 +81,8 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
 
 @SuppressLint("ViewConstructor")
 class ReactExoplayerView extends FrameLayout implements
@@ -416,7 +418,7 @@ class ReactExoplayerView extends FrameLayout implements
         }
     }
 
-    private startBufferCheckTimer() {
+    private void startBufferCheckTimer() {
         SimpleExoPlayer player = this.player;
         VideoEventEmitter eventEmitter = this.eventEmitter;
 
@@ -438,7 +440,7 @@ class ReactExoplayerView extends FrameLayout implements
         this.bufferCheckTimer.scheduleAtFixedRate(bufferCheckTimerTask, 500, 1000);
     }
 
-    private stopBufferCheckTimer() {
+    private void stopBufferCheckTimer() {
         this.bufferCheckTimer.cancel();
         this.bufferCheckTimer = null;
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -421,6 +421,7 @@ class ReactExoplayerView extends FrameLayout implements
     private void startBufferCheckTimer() {
         SimpleExoPlayer player = this.player;
         VideoEventEmitter eventEmitter = this.eventEmitter;
+        Handler mainHandler = this.mainHandler;
 
         if (this.bufferCheckTimer != null) {
             this.stopBufferCheckTimer();
@@ -430,9 +431,15 @@ class ReactExoplayerView extends FrameLayout implements
         TimerTask bufferCheckTimerTask = new TimerTask() {
             @Override
             public void run() {
-                if (player != null) {
-                    double bufferedDuration = (double) (player.getBufferedPercentage() * player.getDuration() / 100);
-                    eventEmitter.bufferProgress(0d, bufferedDuration);
+                if (mainHandler != null) {
+                    mainHandler.post(new Runnable() {
+                        public void run() {
+                            if (player != null) {
+                                double bufferedDuration = (double) (player.getBufferedPercentage() * player.getDuration() / 100);
+                                eventEmitter.bufferProgress(0d, bufferedDuration);
+                            }
+                        }
+                    });
                 }
             };
         };

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -42,6 +42,7 @@ class VideoEventEmitter {
     private static final String EVENT_RESUME = "onPlaybackResume";
     private static final String EVENT_READY = "onReadyForDisplay";
     private static final String EVENT_BUFFER = "onVideoBuffer";
+    private static final String EVENT_BUFFER_PROGRESS = "onVideoBufferProgress";
     private static final String EVENT_IDLE = "onVideoIdle";
     private static final String EVENT_TIMED_METADATA = "onTimedMetadata";
     private static final String EVENT_AUDIO_BECOMING_NOISY = "onVideoAudioBecomingNoisy";
@@ -63,6 +64,7 @@ class VideoEventEmitter {
             EVENT_RESUME,
             EVENT_READY,
             EVENT_BUFFER,
+            EVENT_BUFFER_PROGRESS,
             EVENT_IDLE,
             EVENT_TIMED_METADATA,
             EVENT_AUDIO_BECOMING_NOISY,
@@ -87,6 +89,7 @@ class VideoEventEmitter {
             EVENT_RESUME,
             EVENT_READY,
             EVENT_BUFFER,
+            EVENT_BUFFER_PROGRESS,
             EVENT_IDLE,
             EVENT_TIMED_METADATA,
             EVENT_AUDIO_BECOMING_NOISY,
@@ -104,6 +107,8 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_STEP_FORWARD = "canStepForward";
     private static final String EVENT_PROP_STEP_BACKWARD = "canStepBackward";
 
+    private static final String EVENT_PROP_BUFFER_START = "bufferStart";
+    private static final String EVENT_PROP_BUFFER_END = "bufferEnd";
     private static final String EVENT_PROP_DURATION = "duration";
     private static final String EVENT_PROP_PLAYABLE_DURATION = "playableDuration";
     private static final String EVENT_PROP_SEEKABLE_DURATION = "seekableDuration";
@@ -204,6 +209,13 @@ class VideoEventEmitter {
         WritableMap map = Arguments.createMap();
         map.putBoolean(EVENT_PROP_IS_BUFFERING, isBuffering);
         receiveEvent(EVENT_BUFFER, map);
+    }
+
+    void bufferProgress(int start, int end) {
+        WritableMap map = Arguments.createMap();
+        map.putDouble(EVENT_PROP_BUFFER_START, start);
+        map.putDouble(EVENT_PROP_BUFFER_END, end);
+        receiveEvent(EVENT_BUFFER_PROGRESS, map);
     }
 
     void idle() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -211,7 +211,7 @@ class VideoEventEmitter {
         receiveEvent(EVENT_BUFFER, map);
     }
 
-    void bufferProgress(int start, int end) {
+    void bufferProgress(double start, double end) {
         WritableMap map = Arguments.createMap();
         map.putDouble(EVENT_PROP_BUFFER_START, start);
         map.putDouble(EVENT_PROP_BUFFER_END, end);


### PR DESCRIPTION
- Add support for `onBufferProgress` prop on Android to get buffer data even when the player is paused.