### PR TITLE
VEX-5545: Some Android codecs don't support specific resolutions

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -542,7 +542,7 @@ class ReactExoplayerView extends FrameLayout implements
                     playerNeedsSource = false;
 
                     try {
-                        mimeType = videoSource.getMediaItem().playbackProperties.mimeType
+                        mimeType = videoSource.getMediaItem().playbackProperties.mimeType;
                     } catch (Exception e) {
                         mimeType = null;
                     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -14,7 +14,6 @@ import android.view.Window;
 import android.view.accessibility.CaptioningManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
-import android.webkit.MimeTypeMap;
 
 import com.brentvatne.react.R;
 import com.brentvatne.receiver.AudioBecomingNoisyReceiver;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1310,6 +1310,10 @@ class ReactExoplayerView extends FrameLayout implements
 		for (int i = 0; i < codecCount; ++i) {
             try {
                 MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
+                if (info.getName().startsWith("OMX.google.")) {
+                    // Is a software codec - ignore it
+                    break;
+                }
                 Log.w("ReactExoPlayerViewFormat", "Codec check: " + info.getName());
                 Log.w("ReactExoPlayerViewFormat", "Format: " + String.valueOf(width) + "x" + String.valueOf(height));
                 Log.w("ReactExoPlayerViewFormat", "*************************");

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1286,7 +1286,7 @@ class ReactExoplayerView extends FrameLayout implements
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
 
-        if (!this.extension) {
+        if (this.extension == null) {
             return true;
         }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -170,7 +170,6 @@ class ReactExoplayerView extends FrameLayout implements
     private String drmLicenseUrl = null;
     private String[] drmLicenseHeader = null;
     private boolean controls;
-    private String mimeType;
     // \ End props
 
     // React
@@ -468,6 +467,7 @@ class ReactExoplayerView extends FrameLayout implements
                     ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
                     trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
                     trackSelector.setParameters(trackSelector.buildUponParameters()
+                            .setExceedRendererCapabilitiesIfNecessary(true)​
                             .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
 
                     DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
@@ -540,12 +540,6 @@ class ReactExoplayerView extends FrameLayout implements
                     }
                     player.prepare(mediaSource, !haveResumePosition, false);
                     playerNeedsSource = false;
-
-                    try {
-                        mimeType = videoSource.getMediaItem().playbackProperties.mimeType;
-                    } catch (Exception e) {
-                        mimeType = null;
-                    }
 
                     reLayout(exoPlayerView);
                     eventEmitter.loadStart();
@@ -1293,6 +1287,8 @@ class ReactExoplayerView extends FrameLayout implements
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
 
+        String mimeType = format.sampleMimeType;
+        
         if (mimeType == null) {
             return true;
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -46,6 +46,7 @@ import com.google.android.exoplayer2.drm.HttpMediaDrmCallback;
 import com.google.android.exoplayer2.drm.UnsupportedDrmException;
 import com.google.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
+import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.metadata.MetadataOutput;
 import com.google.android.exoplayer2.source.BehindLiveWindowException;
@@ -478,6 +479,7 @@ class ReactExoplayerView extends FrameLayout implements
                     );
                     DefaultRenderersFactory renderersFactory =
                             new DefaultRenderersFactory(getContext())
+                                    .setEnableDecoderFallback(true)
                                     .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
                     player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
                                 .setTrackSelector​(trackSelector)
@@ -1261,6 +1263,13 @@ class ReactExoplayerView extends FrameLayout implements
                 .build();
         trackSelector.setParameters(selectionParameters);
     }
+
+    /*private boolean isFormatSupported(Format format) {
+        int width = format.width == Format.NO_VALUE ? 0 : format.width;
+        int height = format.height == Format.NO_VALUE ? 0 : format.height;
+        int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
+        MediaCodecInfo.
+    }*/
 
     private int getGroupIndexForDefaultLocale(TrackGroupArray groups) {
         if (groups.length == 0){

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1289,7 +1289,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (this.srcUri == null) {
             return true;
         }
-        String srcExtension = MimeTypeMap.getFileExtensionFromUrl(this.srcUri);
+        String srcExtension = MimeTypeMap.getFileExtensionFromUrl(this.srcUri.toString());
         String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(srcExtension);
         Log.w("ReactExoPlayerViewMime", "MimeType " + mimeType);
         Log.w("ReactExoPlayerViewMime", "Extension " + srcExtension);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1286,9 +1286,13 @@ class ReactExoplayerView extends FrameLayout implements
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
 
+        if (!this.extension) {
+            return true;
+        }
+
         String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(this.extension);
         Log.w("ReactExoPlayerViewMime", "MimeType " + mimeType);
-        Log.w("ReactExoPlayerViewMime", "Extension " + extstension);
+        Log.w("ReactExoPlayerViewMime", "Extension " + this.extension);
 		int codecCount = MediaCodecList.getCodecCount();
 
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1296,7 +1296,7 @@ class ReactExoplayerView extends FrameLayout implements
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
         String mimeType = format.sampleMimeType;
-        String codecType = mimeType.replace('video/', '');
+        String codecType = mimeType.replace("video/", "");
         
         if (mimeType == null) {
             return true;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1295,7 +1295,7 @@ class ReactExoplayerView extends FrameLayout implements
         int width = format.width == Format.NO_VALUE ? 0 : format.width;
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         // int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
-        float framerate = format.framerate == Format.NO_VALUE ? 0 : format.framerate;
+        float frameRate = format.frameRate == Format.NO_VALUE ? 0 : format.frameRate;
         String mimeType = format.sampleMimeType;
         //String codecType = mimeType.replace("video/", "");
         
@@ -1331,7 +1331,7 @@ class ReactExoplayerView extends FrameLayout implements
             } catch(Exception e) {}
 		}*/
         MediaCodecInfo codecInfo = MediaCodecUtil.getDecoderInfo(mimeType, false, false);
-        isSupported = codecInfo.isVideoSizeAndRateSupportedV21(width, height, framerate);
+        isSupported = codecInfo.isVideoSizeAndRateSupportedV21(width, height, frameRate);
         Log.w("ReactExoPlayerViewFormat", "isSupported: " + isSupported);
         // If no codec was found we let the player decide if this Format is supportd
         return isSupported;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -5,8 +5,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaCodecList;
-import android.media.MediaCodecInfo;
-import android.media.MediaCodecInfo.CodecCapabilities;
+import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
+//import android.media.MediaCodecInfo.CodecCapabilities;
 import android.media.MediaFormat;
 import android.net.Uri;
 import android.os.Handler;
@@ -1294,9 +1294,10 @@ class ReactExoplayerView extends FrameLayout implements
     private boolean isFormatSupported(Format format) {
         int width = format.width == Format.NO_VALUE ? 0 : format.width;
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
-        int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
+        // int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
+        int framerate = format.framerate == Format.NO_VALUE ? 0 : format.framerate;
         String mimeType = format.sampleMimeType;
-        String codecType = mimeType.replace("video/", "");
+        //String codecType = mimeType.replace("video/", "");
         
         if (mimeType == null) {
             return true;
@@ -1304,12 +1305,13 @@ class ReactExoplayerView extends FrameLayout implements
 
         Log.w("ReactExoPlayerViewFormat", "Detected mime type for current video: " + mimeType);
         Log.w("ReactExoPlayerViewFormat", "Format requires codec type: " + codecType);
-		int codecCount = MediaCodecList.getCodecCount();
-        MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
+		//int codecCount = MediaCodecList.getCodecCount();
+        //MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
         boolean isSupported = false;
-        boolean isCodecFound = false;
-		for (int i = 0; i < codecCount; ++i) {
+        //boolean isCodecFound = false;
+		/*for (int i = 0; i < codecCount; ++i) {
             try {
+                
                 MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
                 if (!info.getName().contains(codecType)) {
                     // Codec is not meant for this Format
@@ -1327,9 +1329,12 @@ class ReactExoplayerView extends FrameLayout implements
                     break;
                 }
             } catch(Exception e) {}
-		}
+		}*/
+        MediaCodecInfo codecInfo = MediaCodecInfo.getDecoderInfo(mimeType, false, false);
+        isSupported = codecInfo.isVideoSizeAndRateSupportedV21(width, height, framerate);
+        Log.w("ReactExoPlayerViewFormat", "isSupported: " + isSupported);
         // If no codec was found we let the player decide if this Format is supportd
-        return isSupported || !isCodecFound;
+        return isSupported;
     }
 
     private int getGroupIndexForDefaultLocale(TrackGroupArray groups) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1255,7 +1255,7 @@ class ReactExoplayerView extends FrameLayout implements
             
             // Valiate list of all tracks and add only supported formats
             int u = 0;
-            for (int k = 0l; k < allTracks.length; k++) {
+            for (int k = 0; k < allTracks.length; k++) {
                 Format format = group.getFormat(k);
                 if (isFormatSupported(format)) {
                     tracks[u] = allTracks[k];
@@ -1282,16 +1282,22 @@ class ReactExoplayerView extends FrameLayout implements
         int width = format.width == Format.NO_VALUE ? 0 : format.width;
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
-        int codecs = format.codecs == Format.NO_VALUE ? 0 : format.codecs;
+        String codecs = format.codecs;
 
+        if (codecs == null) {
+            // Could not get codec type from format, assume it works
+            return true;
+        }
         String mimeType = MimeTypes.getMediaMimeType​(codecs);
 		int codecCount = MediaCodecList.getCodecCount();
+
+        MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
 
         boolean isSupported = false;
 		for (int i = 0; i < codecCount; ++i) {
 			MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
-            CodecCapabilities codecCapabilities = info.VideoCapabilities.getCapabilitiesForType(mimeType);
-            boolean _isFormatSupported = codecCapabilities.isFormatSupported(format);
+            CodecCapabilities codecCapabilities = info.getCapabilitiesForType(mimeType);
+            boolean _isFormatSupported = codecCapabilities.isFormatSupported(mediaFormat);
             if (_isFormatSupported) {
                 isSupported = true;
                 break;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1286,13 +1286,13 @@ class ReactExoplayerView extends FrameLayout implements
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
 
-        if (this.extension == null) {
+        if (this.srcUri == null) {
             return true;
         }
-
-        String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(this.extension);
+        String srcExtension = MimeTypeMap.getFileExtensionFromUrl(this.srcUri);
+        String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(srcExtension);
         Log.w("ReactExoPlayerViewMime", "MimeType " + mimeType);
-        Log.w("ReactExoPlayerViewMime", "Extension " + this.extension);
+        Log.w("ReactExoPlayerViewMime", "Extension " + srcExtension);
 		int codecCount = MediaCodecList.getCodecCount();
 
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1258,12 +1258,15 @@ class ReactExoplayerView extends FrameLayout implements
             
             // Valiate list of all tracks and add only supported formats
             int u = 0;
+            ArrayList<int> supportedTrackList = new ArrayList<int>();
             for (int k = 0; k < allTracks.length; k++) {
                 Format format = group.getFormat(k);
                 if (isFormatSupported(format)) {
-                    tracks[u] = allTracks[k];
+                    // tracks[u] = allTracks[k];
+                    supportedTrackList.add(allTracks[k]);
                     u++;
                 }
+                tracks = supportedTrackList.toArray();
             }
         }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1330,8 +1330,13 @@ class ReactExoplayerView extends FrameLayout implements
                 }
             } catch(Exception e) {}
 		}*/
-        MediaCodecInfo codecInfo = MediaCodecUtil.getDecoderInfo(mimeType, false, false);
-        isSupported = codecInfo.isVideoSizeAndRateSupportedV21(width, height, frameRate);
+        try {
+            MediaCodecInfo codecInfo = MediaCodecUtil.getDecoderInfo(mimeType, false, false);
+            isSupported = codecInfo.isVideoSizeAndRateSupportedV21(width, height, frameRate);
+        } catch (Exception e) {
+            // Failed to get decoder info - assume it is supported
+            isSupported = true;
+        }
         Log.w("ReactExoPlayerViewFormat", "isSupported: " + isSupported);
         // If no codec was found we let the player decide if this Format is supportd
         return isSupported;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1286,7 +1286,7 @@ class ReactExoplayerView extends FrameLayout implements
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
 
-        String mimeType = MimeTypeMap.getMimeTypeFromExtension(this.extension);
+        String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(this.extension);
         Log.w("ReactExoPlayerViewMime", mimeType);
 		int codecCount = MediaCodecList.getCodecCount();
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -7,6 +7,7 @@ import android.media.AudioManager;
 import android.media.MediaCodecList;
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecInfo.CodecCapabilities;
+import android.media.MediaFormat;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Message;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1295,7 +1295,7 @@ class ReactExoplayerView extends FrameLayout implements
         int width = format.width == Format.NO_VALUE ? 0 : format.width;
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         // int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
-        int framerate = format.framerate == Format.NO_VALUE ? 0 : format.framerate;
+        float framerate = format.framerate == Format.NO_VALUE ? 0 : format.framerate;
         String mimeType = format.sampleMimeType;
         //String codecType = mimeType.replace("video/", "");
         
@@ -1304,7 +1304,7 @@ class ReactExoplayerView extends FrameLayout implements
         }
 
         Log.w("ReactExoPlayerViewFormat", "Detected mime type for current video: " + mimeType);
-        Log.w("ReactExoPlayerViewFormat", "Format requires codec type: " + codecType);
+        // Log.w("ReactExoPlayerViewFormat", "Format requires codec type: " + codecType);
 		//int codecCount = MediaCodecList.getCodecCount();
         //MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
         boolean isSupported = false;
@@ -1330,7 +1330,7 @@ class ReactExoplayerView extends FrameLayout implements
                 }
             } catch(Exception e) {}
 		}*/
-        MediaCodecInfo codecInfo = MediaCodecInfo.getDecoderInfo(mimeType, false, false);
+        MediaCodecInfo codecInfo = MediaCodecUtil.getDecoderInfo(mimeType, false, false);
         isSupported = codecInfo.isVideoSizeAndRateSupportedV21(width, height, framerate);
         Log.w("ReactExoPlayerViewFormat", "isSupported: " + isSupported);
         // If no codec was found we let the player decide if this Format is supportd

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1295,15 +1295,15 @@ class ReactExoplayerView extends FrameLayout implements
         int width = format.width == Format.NO_VALUE ? 0 : format.width;
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
-
+        String codecs = format.codecs;
         String mimeType = format.sampleMimeType;
-        
-        if (mimeType == null) {
+
+        if (mimeType == null || codecs == null) {
             return true;
         }
 
         Log.w("ReactExoPlayerViewFormat", "Detected mime type for current video: " + mimeType);
-        
+        Log.w("ReactExoPlayerViewFormat", "Format requires codecs: " + codecs);)
 		int codecCount = MediaCodecList.getCodecCount();
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
         boolean isSupported = false;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1287,19 +1287,22 @@ class ReactExoplayerView extends FrameLayout implements
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
 
         String mimeType = MimeTypeMap.getMimeTypeFromExtension(this.extension);
+        Log.w("ReactExoPlayerViewMime", mimeType);
 		int codecCount = MediaCodecList.getCodecCount();
 
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
 
         boolean isSupported = false;
 		for (int i = 0; i < codecCount; ++i) {
-			MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
-            CodecCapabilities codecCapabilities = info.getCapabilitiesForType(mimeType);
-            boolean _isFormatSupported = codecCapabilities.isFormatSupported(mediaFormat);
-            if (_isFormatSupported) {
-                isSupported = true;
-                break;
-            }
+            try {
+                MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
+                CodecCapabilities codecCapabilities = info.getCapabilitiesForType(mimeType);
+                boolean _isFormatSupported = codecCapabilities.isFormatSupported(mediaFormat);
+                if (_isFormatSupported) {
+                    isSupported = true;
+                    break;
+                }
+            } catch(Exception e) {}
 		}
         return isSupported;
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1310,6 +1310,9 @@ class ReactExoplayerView extends FrameLayout implements
 		for (int i = 0; i < codecCount; ++i) {
             try {
                 MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
+                Log.w("ReactExoPlayerViewFormat", "Codec check: " + info.getName());
+                Log.w("ReactExoPlayerViewFormat", "Format: " + width.toString() + "x" + height.toString());
+                Log.w("ReactExoPlayerViewFormat", "*************************");
                 CodecCapabilities codecCapabilities = info.getCapabilitiesForType(mimeType);
                 boolean _isFormatSupported = codecCapabilities.isFormatSupported(mediaFormat);
                 if (_isFormatSupported) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1306,6 +1306,7 @@ class ReactExoplayerView extends FrameLayout implements
         Log.w("ReactExoPlayerViewFormat", "Format requires codecs: " + codecs);
 		int codecCount = MediaCodecList.getCodecCount();
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
+        mediaFormat.setString(MediaFormat.KEY_CODECS_STRING, codecs);
         boolean isSupported = false;
 		for (int i = 0; i < codecCount; ++i) {
             try {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.media.AudioManager;
-import android.media.MediaCodecList;
-import android.media.MediaFormat;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Message;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1303,7 +1303,7 @@ class ReactExoplayerView extends FrameLayout implements
         }
 
         Log.w("ReactExoPlayerViewFormat", "Detected mime type for current video: " + mimeType);
-        Log.w("ReactExoPlayerViewFormat", "Format requires codecs: " + codecs);)
+        Log.w("ReactExoPlayerViewFormat", "Format requires codecs: " + codecs);
 		int codecCount = MediaCodecList.getCodecCount();
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
         boolean isSupported = false;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -18,6 +18,7 @@ import android.view.Window;
 import android.view.accessibility.CaptioningManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
+import android.webkit.MimeTypeMap;
 
 import com.brentvatne.react.R;
 import com.brentvatne.receiver.AudioBecomingNoisyReceiver;
@@ -77,7 +78,6 @@ import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.util.Assertions;
 import com.google.android.exoplayer2.util.Util;
-import com.google.android.exoplayer2.util.MimeTypes;
 
 import java.net.CookieHandler;
 import java.net.CookieManager;
@@ -1285,13 +1285,8 @@ class ReactExoplayerView extends FrameLayout implements
         int width = format.width == Format.NO_VALUE ? 0 : format.width;
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
-        String codecs = format.codecs;
 
-        if (codecs == null) {
-            // Could not get codec type from format, assume it works
-            return true;
-        }
-        String mimeType = MimeTypes.getMediaMimeType​(codecs);
+        String mimeType = MimeTypeMap.getMimeTypeFromExtension(this.extension);
 		int codecCount = MediaCodecList.getCodecCount();
 
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1257,16 +1257,23 @@ class ReactExoplayerView extends FrameLayout implements
             }
             
             // Valiate list of all tracks and add only supported formats
-            int u = 0;
-            ArrayList<int> supportedTrackList = new ArrayList<int>();
+            int supportedFormatLength = 0;
+            ArrayList<Integer> supportedTrackList = new ArrayList<Integer>();
+            for (int g = 0; g < allTracks.length; g++) {
+                Format format = group.getFormat(k);
+                if (isFormatSupported(format)) {
+                    supportedFormatLength++;
+                }
+            }
+            tracks = new int[supportedFormatLength + 1];
+            int o = 0;
             for (int k = 0; k < allTracks.length; k++) {
                 Format format = group.getFormat(k);
                 if (isFormatSupported(format)) {
-                    // tracks[u] = allTracks[k];
+                    tracks[o] = allTracks[k];
                     supportedTrackList.add(allTracks[k]);
-                    u++;
+                    o++;
                 }
-                tracks = supportedTrackList.toArray();
             }
         }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -467,7 +467,6 @@ class ReactExoplayerView extends FrameLayout implements
                     ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
                     trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
                     trackSelector.setParameters(trackSelector.buildUponParameters()
-                            .setExceedRendererCapabilitiesIfNecessary(true)​
                             .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
 
                     DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -927,7 +927,9 @@ class ReactExoplayerView extends FrameLayout implements
                 videoTrack.putString("codecs", format.codecs != null ? format.codecs : "");
                 videoTrack.putString("trackId",
                         format.id == null ? String.valueOf(trackIndex) : format.id);
-                videoTracks.pushMap(videoTrack);
+                if (isFormatSupported(format)) {
+                    videoTracks.pushMap(videoTrack);
+                }
             }
         }
         return videoTracks;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1311,7 +1311,7 @@ class ReactExoplayerView extends FrameLayout implements
             try {
                 MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
                 Log.w("ReactExoPlayerViewFormat", "Codec check: " + info.getName());
-                Log.w("ReactExoPlayerViewFormat", "Format: " + width.toString() + "x" + height.toString());
+                Log.w("ReactExoPlayerViewFormat", "Format: " + String.valueOf(width) + "x" + String.valueOf(height));
                 Log.w("ReactExoPlayerViewFormat", "*************************");
                 CodecCapabilities codecCapabilities = info.getCapabilitiesForType(mimeType);
                 boolean _isFormatSupported = codecCapabilities.isFormatSupported(mediaFormat);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -170,6 +170,7 @@ class ReactExoplayerView extends FrameLayout implements
     private String drmLicenseUrl = null;
     private String[] drmLicenseHeader = null;
     private boolean controls;
+    private String mimeType;
     // \ End props
 
     // React
@@ -539,6 +540,12 @@ class ReactExoplayerView extends FrameLayout implements
                     }
                     player.prepare(mediaSource, !haveResumePosition, false);
                     playerNeedsSource = false;
+
+                    try {
+                        mimeType = videoSource.getMediaItem().playbackProperties.mimeType
+                    } catch (Exception e) {
+                        mimeType = null;
+                    }
 
                     reLayout(exoPlayerView);
                     eventEmitter.loadStart();
@@ -1286,17 +1293,14 @@ class ReactExoplayerView extends FrameLayout implements
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
 
-        if (this.srcUri == null) {
+        if (mimeType == null) {
             return true;
         }
-        String srcExtension = MimeTypeMap.getFileExtensionFromUrl(this.srcUri.toString());
-        String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(srcExtension);
-        Log.w("ReactExoPlayerViewMime", "MimeType " + mimeType);
-        Log.w("ReactExoPlayerViewMime", "Extension " + srcExtension);
+
+        Log.w("ReactExoPlayerViewFormat", "Detected mime type for current video: " + mimeType);
+        
 		int codecCount = MediaCodecList.getCodecCount();
-
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
-
         boolean isSupported = false;
 		for (int i = 0; i < codecCount; ++i) {
             try {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -5,8 +5,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaCodecList;
-import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
-//import android.media.MediaCodecInfo.CodecCapabilities;
 import android.media.MediaFormat;
 import android.net.Uri;
 import android.os.Handler;
@@ -49,6 +47,7 @@ import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
 import com.google.android.exoplayer2.drm.HttpMediaDrmCallback;
 import com.google.android.exoplayer2.drm.UnsupportedDrmException;
+import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 import com.google.android.exoplayer2.metadata.Metadata;
@@ -483,7 +482,6 @@ class ReactExoplayerView extends FrameLayout implements
                     );
                     DefaultRenderersFactory renderersFactory =
                             new DefaultRenderersFactory(getContext())
-                                    .setEnableDecoderFallback(true)
                                     .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
                     player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
                                 .setTrackSelector​(trackSelector)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1294,42 +1294,12 @@ class ReactExoplayerView extends FrameLayout implements
     private boolean isFormatSupported(Format format) {
         int width = format.width == Format.NO_VALUE ? 0 : format.width;
         int height = format.height == Format.NO_VALUE ? 0 : format.height;
-        // int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
         float frameRate = format.frameRate == Format.NO_VALUE ? 0 : format.frameRate;
         String mimeType = format.sampleMimeType;
-        //String codecType = mimeType.replace("video/", "");
-        
         if (mimeType == null) {
             return true;
         }
-
-        Log.w("ReactExoPlayerViewFormat", "Detected mime type for current video: " + mimeType);
-        // Log.w("ReactExoPlayerViewFormat", "Format requires codec type: " + codecType);
-		//int codecCount = MediaCodecList.getCodecCount();
-        //MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);
         boolean isSupported = false;
-        //boolean isCodecFound = false;
-		/*for (int i = 0; i < codecCount; ++i) {
-            try {
-                
-                MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
-                if (!info.getName().contains(codecType)) {
-                    // Codec is not meant for this Format
-                    continue;
-                }
-                isCodecFound = true;
-                Log.w("ReactExoPlayerViewFormat", "Codec check: " + info.getName());
-                Log.w("ReactExoPlayerViewFormat", "Format: " + String.valueOf(width) + "x" + String.valueOf(height));
-                CodecCapabilities codecCapabilities = info.getCapabilitiesForType(mimeType);
-                boolean _isFormatSupported = codecCapabilities.isFormatSupported(mediaFormat);
-                Log.w("ReactExoPlayerViewFormat", "isSupported: " + String.valueOf(_isFormatSupported));
-                Log.w("ReactExoPlayerViewFormat", "*************************");
-                if (_isFormatSupported) {
-                    isSupported = true;
-                    break;
-                }
-            } catch(Exception e) {}
-		}*/
         try {
             MediaCodecInfo codecInfo = MediaCodecUtil.getDecoderInfo(mimeType, false, false);
             isSupported = codecInfo.isVideoSizeAndRateSupportedV21(width, height, frameRate);
@@ -1337,8 +1307,6 @@ class ReactExoplayerView extends FrameLayout implements
             // Failed to get decoder info - assume it is supported
             isSupported = true;
         }
-        Log.w("ReactExoPlayerViewFormat", "isSupported: " + isSupported);
-        // If no codec was found we let the player decide if this Format is supportd
         return isSupported;
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1260,7 +1260,7 @@ class ReactExoplayerView extends FrameLayout implements
             int supportedFormatLength = 0;
             ArrayList<Integer> supportedTrackList = new ArrayList<Integer>();
             for (int g = 0; g < allTracks.length; g++) {
-                Format format = group.getFormat(k);
+                Format format = group.getFormat(g);
                 if (isFormatSupported(format)) {
                     supportedFormatLength++;
                 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1287,7 +1287,8 @@ class ReactExoplayerView extends FrameLayout implements
         int bitrate = format.bitrate == Format.NO_VALUE ? 0 : format.bitrate; 
 
         String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(this.extension);
-        Log.w("ReactExoPlayerViewMime", mimeType);
+        Log.w("ReactExoPlayerViewMime", "MimeType " + mimeType);
+        Log.w("ReactExoPlayerViewMime", "Extension " + extstension);
 		int codecCount = MediaCodecList.getCodecCount();
 
         MediaFormat mediaFormat = MediaFormat.createVideoFormat(mimeType, width, height);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1310,15 +1310,12 @@ class ReactExoplayerView extends FrameLayout implements
 		for (int i = 0; i < codecCount; ++i) {
             try {
                 MediaCodecInfo info = MediaCodecList.getCodecInfoAt(i);
-                if (info.getName().startsWith("OMX.google.")) {
-                    // Is a software codec - ignore it
-                    break;
-                }
                 Log.w("ReactExoPlayerViewFormat", "Codec check: " + info.getName());
                 Log.w("ReactExoPlayerViewFormat", "Format: " + String.valueOf(width) + "x" + String.valueOf(height));
-                Log.w("ReactExoPlayerViewFormat", "*************************");
                 CodecCapabilities codecCapabilities = info.getCapabilitiesForType(mimeType);
                 boolean _isFormatSupported = codecCapabilities.isFormatSupported(mediaFormat);
+                Log.w("ReactExoPlayerViewFormat", "isSupported: " + String.valueOf(_isFormatSupported));
+                Log.w("ReactExoPlayerViewFormat", "*************************");
                 if (_isFormatSupported) {
                     isSupported = true;
                     break;


### PR DESCRIPTION
Add support for detecting if format is supported and exclude unsupported resolutions from auto quality selection and video track info in RN.