### PR TITLE
VEX-6030: Further prevent memory crashes

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -450,7 +450,7 @@ class ReactExoplayerView extends FrameLayout implements
                 return false;
             }
             if (runtime.freeMemory() == 0) {
-                Log.w("ExoPlayer Warning", "free memory reached 0, forcing garbage collection");
+                Log.w("ExoPlayer Warning", "Free memory reached 0, forcing garbage collection");
                 runtime.gc();
                 return false;
             }


### PR DESCRIPTION
This PR is intended to prevent memory crashes when the free memory runs out

Jira: VEX-6030
https://jira.tenkasu.net/browse/VEX-6030

Velocity PR: https://github.com/crunchyroll/velocity/pull/2043

By forcefully calling the garbage collector the memory crashes, specially on lower resolutions (<720p) are gone on devices with 2GB of ram or less and Android 6, also testing 3GB Android 7 with this patch, so far is working as intended

### Reviews
- Major reviewer (domain expert): @nickfujita 
- Minor reviewer: @jctorresM 

### Testing instructions

```
1. Target an android 6 device with 2GB of ram or less
2. Execute yarn start-androidmobile-client
3. Make sure to enable "V2" at "config delta override"
4. Play any episode
5. Skip to the middle then near the end
6. Play the next episode
7. Skip to another part of the video
8. Make sure the video plays normally with no crashes
```
