### PR TITLE
VEX-6184: Fix skip while buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ maxBufferMs | number | The default maximum duration of media that the player wil
 bufferForPlaybackMs | number | The default duration of media that must be buffered for playback to start or resume following a user action such as a seek, in milliseconds.
 bufferForPlaybackAfterRebufferMs | number | The default duration of media that must be buffered for playback to resume after a rebuffer, in milliseconds. A rebuffer is defined to be caused by buffer depletion rather than a user action.
 maxHeapAllocationPercent | number | The percentage of available heap that the video can use to buffer, between 0 and 1
+maxCacheSize | number | The cache size in MegaBytes to use for local buffering
 
 This prop should only be set when you are setting the source, changing it after the media is loaded will cause it to be reloaded.
 

--- a/Video.js
+++ b/Video.js
@@ -469,6 +469,7 @@ Video.propTypes = {
     bufferForPlaybackMs: PropTypes.number,
     bufferForPlaybackAfterRebufferMs: PropTypes.number,
     maxHeapAllocationPercent: PropTypes.number,
+    maxCacheSize: PropTypes.number,
   }),
   stereoPan: PropTypes.number,
   rate: PropTypes.number,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -56,6 +56,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_BUFFER_CONFIG_BUFFER_FOR_PLAYBACK_MS = "bufferForPlaybackMs";
     private static final String PROP_BUFFER_CONFIG_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = "bufferForPlaybackAfterRebufferMs";
     private static final String PROP_BUFFER_CONFIG_MAX_HEAP_ALLOCATION_PERCENT = "maxHeapAllocationPercent";
+    private static final String PROP_BUFFER_CONFIG_MAX_CACHE_SIZE = "maxCacheSize";
+    private static final String PROP_ENABLE_CACHE = "enableCache";
     private static final String PROP_PREVENTS_DISPLAY_SLEEP_DURING_VIDEO_PLAYBACK = "preventsDisplaySleepDuringVideoPlayback";
     private static final String PROP_PROGRESS_UPDATE_INTERVAL = "progressUpdateInterval";
     private static final String PROP_REPORT_BANDWIDTH = "reportBandwidth";
@@ -346,6 +348,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         int bufferForPlaybackMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS;
         int bufferForPlaybackAfterRebufferMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS;
         double maxHeapAllocationPercent = ReactExoplayerView.DEFAULT_MAX_HEAP_ALLOCATION_PERCENT;
+        int maxCacheSize = ReactExoplayerView.DEFAULT_MAX_CACHE_SIZE;
         if (bufferConfig != null) {
             minBufferMs = bufferConfig.hasKey(PROP_BUFFER_CONFIG_MIN_BUFFER_MS)
                     ? bufferConfig.getInt(PROP_BUFFER_CONFIG_MIN_BUFFER_MS) : minBufferMs;
@@ -357,7 +360,14 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
                     ? bufferConfig.getInt(PROP_BUFFER_CONFIG_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS) : bufferForPlaybackAfterRebufferMs;
             maxHeapAllocationPercent = bufferConfig.hasKey(PROP_BUFFER_CONFIG_MAX_HEAP_ALLOCATION_PERCENT)
                     ? bufferConfig.getDouble(PROP_BUFFER_CONFIG_MAX_HEAP_ALLOCATION_PERCENT) : maxHeapAllocationPercent;
+            maxCacheSize = bufferConfig.hasKey(PROP_BUFFER_CONFIG_MAX_CACHE_SIZE)
+                    ? bufferConfig.getInt(PROP_BUFFER_CONFIG_MAX_CACHE_SIZE) : maxCacheSize;
             videoView.setBufferConfig(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs, maxHeapAllocationPercent);
+            if (maxCacheSize > 0) {
+                videoView.enableCache(maxCacheSize);
+            } else {
+                videoView.disableCache();
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes the skip backwards button while video is buffering

Jira: VEX-6184
https://jira.tenkasu.net/browse/VEX-6184

By adding a `SimpleCache` to the `mediaDataSourceFactory` the playback can store fragments of videos to the device storage, this cache allows both a faster startup and some functionalities while the video is buffering.

Velocity PR: https://github.com/crunchyroll/velocity/pull/2061

### Reviews
- Major reviewer (domain expert): @armadilio3 
- Minor reviewer: @jctorresM 

### Testing instructions

```
1. Execute yarn start-androidmobile-client
2. Enable "V2" at "config delta override"
3. Play any video
4. Put the device on airplane mode
5. When the buffer runs out press skip back
6. Check the video skips back as when online
```
Note: Do not merge until react-native-video PR has been merged and tagged