### PR TITLE
VEX-6540: Disable recording when playing local videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ var styles = StyleSheet.create({
 * [textTracks](#texttracks)
 * [trackId](#trackId)
 * [useTextureView](#usetextureview)
+* [useSecureView](#useSecureView)
 * [volume](#volume)
 * [localSourceEncryptionKeyScheme](#localSourceEncryptionKeyScheme)
 
@@ -908,6 +909,18 @@ useTextureView can only be set at same time you're setting the source.
 
 * **true (default)** - Use a TextureView
 * **false** - Use a SurfaceView
+
+Platforms: Android ExoPlayer
+
+#### useSecureView
+Force the output to a SurfaceView and enables the secure surface.
+
+This will override useTextureView flag.
+
+SurfaceView is is the only one that can be labeled as secure.
+
+* **true** - Use security
+* **false (default)** - Do not use security
 
 Platforms: Android ExoPlayer
 

--- a/Video.js
+++ b/Video.js
@@ -488,6 +488,7 @@ Video.propTypes = {
   fullscreenOrientation: PropTypes.oneOf(['all', 'landscape', 'portrait']),
   progressUpdateInterval: PropTypes.number,
   useTextureView: PropTypes.bool,
+  useSecureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,
   onLoad: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -41,6 +41,7 @@ public final class ExoPlayerView extends FrameLayout {
     private ViewGroup.LayoutParams layoutParams;
 
     private boolean useTextureView = true;
+    private boolean useSecureView = false;
     private boolean hideShutterView = false;
 
     public ExoPlayerView(Context context) {
@@ -103,7 +104,15 @@ public final class ExoPlayerView extends FrameLayout {
     }
 
     private void updateSurfaceView() {
-        View view = useTextureView ? new TextureView(context) : new SurfaceView(context);
+        View view;
+        if (!useTextureView || useSecureView) {
+            view = new SurfaceView(context);
+            if (useSecureView) {
+                ((SurfaceView)view).setSecure(true);
+            }
+        } else {
+            view = new TextureView(context);
+        }
         view.setLayoutParams(layoutParams);
 
         surfaceView = view;
@@ -174,6 +183,13 @@ public final class ExoPlayerView extends FrameLayout {
     public void setUseTextureView(boolean useTextureView) {
         if (useTextureView != this.useTextureView) {
             this.useTextureView = useTextureView;
+            updateSurfaceView();
+        }
+    }
+
+    public void useSecureView(boolean useSecureView) {
+        if (useSecureView != this.useSecureView) {
+            this.useSecureView = useSecureView;
             updateSurfaceView();
         }
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1696,6 +1696,10 @@ class ReactExoplayerView extends FrameLayout implements
         exoPlayerView.setUseTextureView(finallyUseTextureView);
     }
 
+    public void useSecureView(boolean useSecureView) {
+        exoPlayerView.useSecureView(useSecureView);
+    }
+
     public void setHideShutterView(boolean hideShutterView) {
         exoPlayerView.setHideShutterView(hideShutterView);
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -72,6 +72,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_DISABLE_DISCONNECT_ERROR = "disableDisconnectError";
     private static final String PROP_FULLSCREEN = "fullscreen";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
+    private static final String PROP_SECURE_VIEW = "useSecureView";
     private static final String PROP_SELECTED_VIDEO_TRACK = "selectedVideoTrack";
     private static final String PROP_SELECTED_VIDEO_TRACK_TYPE = "type";
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
@@ -329,6 +330,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = true)
     public void setUseTextureView(final ReactExoplayerView videoView, final boolean useTextureView) {
         videoView.setUseTextureView(useTextureView);
+    }
+
+    @ReactProp(name = PROP_SECURE_VIEW, defaultBoolean = true)
+    public void useSecureView(final ReactExoplayerView videoView, final boolean useSecureView) {
+        videoView.useSecureView(useSecureView);
     }
 
     @ReactProp(name = PROP_HIDE_SHUTTER_VIEW, defaultBoolean = false)


### PR DESCRIPTION
This PR adds core actions to enable or disable screenshots

Jira: VEX-6540
https://jira.tenkasu.net/browse/VEX-6540

velocity PR: https://github.com/crunchyroll/velocity/pull/2248

New core actions were added to control the player surface and mark it as secure. Sending the prop to `react-native-video` will recreate the surface of the player changing it to a SurfaceView and enabling security

### Reviews
- Major reviewer (domain expert): @nickfujita
- Minor reviewer: @armadilio3 
### PR Checklist
- [/] Unit tests have been written
- [x] Documentation has been created and/or updated

### Testing instructions

Android mobile
```
Pure offline

1. execute yarn start-androidmobile-client
2. log in as mega fan
3. download an episode
4. turn on airplane mode
5. play the downloaded episode
6. try to take a screenshot, confirm the screenshot do not include any content

Online client playing offline content

7. turn off airplane mode
8. go to the app home
9. resume the downloaded video from continue watching
10. try to take a screenshot, confirm the screenshot do not include any content
```
