### PR TITLE
VEX-6265: Android: Phone's soft buttons are shown in fullscreen mode while casting

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -144,6 +144,7 @@ class ReactExoplayerView extends FrameLayout implements
     private long resumePosition;
     private boolean loadVideoStarted;
     private boolean isFullscreen;
+    private boolean isFullscreenHandlingDisabled;
     private boolean isInBackground;
     private boolean isPaused;
     private boolean isBuffering;
@@ -1658,6 +1659,10 @@ class ReactExoplayerView extends FrameLayout implements
         this.disableDisconnectError = disableDisconnectError;
     }
 
+    public void setDisableFullscreenHandling(boolean isFullscreenHandlingDisabled) {
+        this.isFullscreenHandlingDisabled = isFullscreenHandlingDisabled;
+    }
+
     public void setFullscreen(boolean fullscreen) {
         if (fullscreen == isFullscreen) {
             return; // Avoid generating events when nothing is changing
@@ -1681,12 +1686,16 @@ class ReactExoplayerView extends FrameLayout implements
                         | SYSTEM_UI_FLAG_FULLSCREEN;
             }
             eventEmitter.fullscreenWillPresent();
-            decorView.setSystemUiVisibility(uiOptions);
+            if (!isFullscreenHandlingDisabled) {
+                decorView.setSystemUiVisibility(uiOptions);
+            }
             eventEmitter.fullscreenDidPresent();
         } else {
             uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
             eventEmitter.fullscreenWillDismiss();
-            decorView.setSystemUiVisibility(uiOptions);
+            if (!isFullscreenHandlingDisabled) {
+                decorView.setSystemUiVisibility(uiOptions);
+            }
             eventEmitter.fullscreenDidDismiss();
         }
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -71,7 +71,6 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_DISABLE_BUFFERING = "disableBuffering";
     private static final String PROP_DISABLE_DISCONNECT_ERROR = "disableDisconnectError";
     private static final String PROP_FULLSCREEN = "fullscreen";
-    private static final String PROP_DISABLE_FULLSCREEN_HANDLING = "disableFullscreenHandling";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
     private static final String PROP_SECURE_VIEW = "useSecureView";
     private static final String PROP_SELECTED_VIDEO_TRACK = "selectedVideoTrack";
@@ -326,11 +325,6 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_FULLSCREEN, defaultBoolean = false)
     public void setFullscreen(final ReactExoplayerView videoView, final boolean fullscreen) {
         videoView.setFullscreen(fullscreen);
-    }
-
-    @ReactProp(name = PROP_DISABLE_FULLSCREEN_HANDLING, defaultBoolean = false)
-    public void setDisableFullscreenHandling(final ReactExoplayerView videoView, final boolean fullscreenHandlingDisabled) {
-        videoView.setDisableFullscreenHandling(fullscreenHandlingDisabled);
     }
 
     @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = true)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -71,6 +71,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_DISABLE_BUFFERING = "disableBuffering";
     private static final String PROP_DISABLE_DISCONNECT_ERROR = "disableDisconnectError";
     private static final String PROP_FULLSCREEN = "fullscreen";
+    private static final String PROP_DISABLE_FULLSCREEN_HANDLING = "disableFullscreenHandling";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
     private static final String PROP_SECURE_VIEW = "useSecureView";
     private static final String PROP_SELECTED_VIDEO_TRACK = "selectedVideoTrack";
@@ -325,6 +326,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_FULLSCREEN, defaultBoolean = false)
     public void setFullscreen(final ReactExoplayerView videoView, final boolean fullscreen) {
         videoView.setFullscreen(fullscreen);
+    }
+
+    @ReactProp(name = PROP_DISABLE_FULLSCREEN_HANDLING, defaultBoolean = false)
+    public void setDisableFullscreenHandling(final ReactExoplayerView videoView, final boolean fullscreenHandlingDisabled) {
+        videoView.setDisableFullscreenHandling(fullscreenHandlingDisabled);
     }
 
     @ReactProp(name = PROP_USE_TEXTURE_VIEW, defaultBoolean = true)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -71,6 +71,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_DISABLE_BUFFERING = "disableBuffering";
     private static final String PROP_DISABLE_DISCONNECT_ERROR = "disableDisconnectError";
     private static final String PROP_FULLSCREEN = "fullscreen";
+    private static final String PROP_DISABLE_FULLSCREEN_HANDLING = "disableFullscreenHandling";
     private static final String PROP_USE_TEXTURE_VIEW = "useTextureView";
     private static final String PROP_SECURE_VIEW = "useSecureView";
     private static final String PROP_SELECTED_VIDEO_TRACK = "selectedVideoTrack";
@@ -320,6 +321,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_DISABLE_DISCONNECT_ERROR, defaultBoolean = false)
     public void setDisableDisconnectError(final ReactExoplayerView videoView, final boolean disableDisconnectError) {
         videoView.setDisableDisconnectError(disableDisconnectError);
+    }
+
+    @ReactProp(name = PROP_DISABLE_FULLSCREEN_HANDLING, defaultBoolean = false)
+    public void setDisableFullscreenHandling(final ReactExoplayerView videoView, final boolean fullscreenHandlingDisabled) {
+        videoView.setDisableFullscreenHandling(fullscreenHandlingDisabled);
     }
 
     @ReactProp(name = PROP_FULLSCREEN, defaultBoolean = false)

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -133,6 +133,7 @@ public class ReactVideoView extends ScalableVideoView implements
     private boolean mPlayInBackground = false;
     private boolean mBackgroundPaused = false;
     private boolean mIsFullscreen = false;
+    private boolean mIsFullscreenHandlingDisabled = false;
 
     private int mMainVer = 0;
     private int mPatchVer = 0;
@@ -490,6 +491,10 @@ public class ReactVideoView extends ScalableVideoView implements
         }
     }
 
+    public void setDisableFullscreenHandling(boolean isFullscreenHandlingDisabled) {
+        mIsFullscreenHandlingDisabled = isFullscreenHandlingDisabled;
+    }
+
     public void setFullscreen(boolean isFullscreen) {
         if (isFullscreen == mIsFullscreen) {
             return; // Avoid generating events when nothing is changing
@@ -513,12 +518,18 @@ public class ReactVideoView extends ScalableVideoView implements
                         | SYSTEM_UI_FLAG_FULLSCREEN;
             }
             mEventEmitter.receiveEvent(getId(), Events.EVENT_FULLSCREEN_WILL_PRESENT.toString(), null);
-            decorView.setSystemUiVisibility(uiOptions);
+            if (!mIsFullscreenHandlingDisabled) {
+                // Do not modify system UI when fullscreen handling is disabled
+                decorView.setSystemUiVisibility(uiOptions);
+            }
             mEventEmitter.receiveEvent(getId(), Events.EVENT_FULLSCREEN_DID_PRESENT.toString(), null);
         } else {
             uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
             mEventEmitter.receiveEvent(getId(), Events.EVENT_FULLSCREEN_WILL_DISMISS.toString(), null);
-            decorView.setSystemUiVisibility(uiOptions);
+            if (!mIsFullscreenHandlingDisabled) {
+            // Do not modify system UI when fullscreen handling is disabled
+                decorView.setSystemUiVisibility(uiOptions);
+            }
             mEventEmitter.receiveEvent(getId(), Events.EVENT_FULLSCREEN_DID_DISMISS.toString(), null);
         }
     }

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -527,7 +527,7 @@ public class ReactVideoView extends ScalableVideoView implements
             uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
             mEventEmitter.receiveEvent(getId(), Events.EVENT_FULLSCREEN_WILL_DISMISS.toString(), null);
             if (!mIsFullscreenHandlingDisabled) {
-            // Do not modify system UI when fullscreen handling is disabled
+                // Do not modify system UI when fullscreen handling is disabled
                 decorView.setSystemUiVisibility(uiOptions);
             }
             mEventEmitter.receiveEvent(getId(), Events.EVENT_FULLSCREEN_DID_DISMISS.toString(), null);

--- a/android/src/main/java/com/brentvatne/react/ReactVideoViewManager.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoViewManager.java
@@ -37,6 +37,7 @@ public class ReactVideoViewManager extends SimpleViewManager<ReactVideoView> {
     public static final String PROP_SEEK = "seek";
     public static final String PROP_RATE = "rate";
     public static final String PROP_FULLSCREEN = "fullscreen";
+    public static final String PROP_DISABLE_FULLSCREEN_HANDLING = "disableFullscreenHandling";
     public static final String PROP_PLAY_IN_BACKGROUND = "playInBackground";
     public static final String PROP_CONTROLS = "controls";
 
@@ -153,6 +154,11 @@ public class ReactVideoViewManager extends SimpleViewManager<ReactVideoView> {
     @ReactProp(name = PROP_RATE)
     public void setRate(final ReactVideoView videoView, final float rate) {
         videoView.setRateModifier(rate);
+    }
+
+    @ReactProp(name = PROP_DISABLE_FULLSCREEN_HANDLING, defaultBoolean = false)
+    public void setDisableFullscreenHandling(final ReactExoplayerView videoView, final boolean fullscreenHandlingDisabled) {
+        videoView.setDisableFullscreenHandling(fullscreenHandlingDisabled);
     }
 
     @ReactProp(name = PROP_FULLSCREEN, defaultBoolean = false)


### PR DESCRIPTION
Add show nav bar native method and handling while casting.

Jira: VEX-6265
https://jira.tenkasu.net/browse/VEX-6265

Usually nav bar handling is done by RN Video but when we are casting we disable RNV so we need to manually handle show/hide logic for nav bar. This has been done in the google cast module by listening to enter/exit fullscreen sagas which show/hide nav bar, in addition some changes were made to RNV to make the hand off from RNV to Velocity is smoother.