### PR TITLE
VEX-6778: Android: React Native video getVideoTrackInfoFromManifest crash

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -986,9 +986,9 @@ class ReactExoplayerView extends FrameLayout implements
         }
         return audioTracks;
     }
-    private WritableArray getVideoTrackInfo() {
+    private WritableArray getVideoTrackInfo(Timeline timelineRef) {
 
-        WritableArray contentVideoTracks = this.getVideoTrackInfoFromManifest();
+        WritableArray contentVideoTracks = this.getVideoTrackInfoFromManifest(timelineRef);
         if (contentVideoTracks != null) {
             isUsingContentResolution = true;
             return contentVideoTracks;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -945,14 +945,14 @@ class ReactExoplayerView extends FrameLayout implements
             int height = videoFormat != null ? videoFormat.height : 0;
             String trackId = videoFormat != null ? videoFormat.id : "-1";
 
+            long duration = player.getDuration();
+            long currentPosition = player.getCurrentPosition();
+            WritableArray audioTrackInfo = getAudioTrackInfo();
+            WritableArray textTrackInfo = getTextTrackInfo();
+            Timeline timelineRef = player.getCurrentTimeline();
+
             ExecutorService es = Executors.newSingleThreadExecutor();
             es.execute(new Runnable() {
-
-                long duration = player.getDuration();
-                long currentPosition = player.getCurrentPosition();
-                WritableArray audioTrackInfo = getAudioTrackInfo();
-                WritableArray textTrackInfo = getTextTrackInfo();
-                Timeline timelineRef = player.getCurrentTimeline();
 
                 @Override
                 public void run() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1006,8 +1006,7 @@ class ReactExoplayerView extends FrameLayout implements
                 videoTrack.putInt("height",format.height == Format.NO_VALUE ? 0 : format.height);
                 videoTrack.putInt("bitrate", format.bitrate == Format.NO_VALUE ? 0 : format.bitrate);
                 videoTrack.putString("codecs", format.codecs != null ? format.codecs : "");
-                videoTrack.putString("trackId",
-                        format.id == null ? String.valueOf(trackIndex) : format.id);
+                videoTrack.putString("trackId", format.id == null ? String.valueOf(trackIndex) : format.id);
                 if (isFormatSupported(format)) {
                     videoTracks.pushMap(videoTrack);
                 }
@@ -1018,7 +1017,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private WritableArray getVideoTrackInfoFromManifest() {
-        this.getVideoTrackInfoFromManifest(0);
+        return this.getVideoTrackInfoFromManifest(0);
     }
 
     private WritableArray getVideoTrackInfoFromManifest(int retryCount) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1041,6 +1041,7 @@ class ReactExoplayerView extends FrameLayout implements
 
             public WritableArray call() throws Exception {
                 WritableArray videoTracks = Arguments.createArray();
+                Thread.sleep(3500);
                 try  {
                     DashManifest manifest = DashUtil.loadManifest(this.ds, this.uri);
                     int periodCount = manifest.getPeriodCount();

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -950,6 +950,7 @@ class ReactExoplayerView extends FrameLayout implements
             WritableArray audioTrackInfo = getAudioTrackInfo();
             WritableArray textTrackInfo = getTextTrackInfo();
             Timeline timelineRef = player.getCurrentTimeline();
+            int trackRendererIndex = getTrackRendererIndex(C.TRACK_TYPE_VIDEO);
 
             ExecutorService es = Executors.newSingleThreadExecutor();
             es.execute(new Runnable() {
@@ -957,7 +958,7 @@ class ReactExoplayerView extends FrameLayout implements
                 @Override
                 public void run() {
                     eventEmitter.load(duration, currentPosition, width, height,
-                        audioTrackInfo, textTrackInfo, getVideoTrackInfo(timelineRef), trackId);
+                        audioTrackInfo, textTrackInfo, getVideoTrackInfo(timelineRef, trackRendererIndex), trackId);
                 }
             });
         }
@@ -986,7 +987,7 @@ class ReactExoplayerView extends FrameLayout implements
         }
         return audioTracks;
     }
-    private WritableArray getVideoTrackInfo(Timeline timelineRef) {
+    private WritableArray getVideoTrackInfo(Timeline timelineRef, int trackRendererIndex) {
 
         WritableArray contentVideoTracks = this.getVideoTrackInfoFromManifest(timelineRef);
         if (contentVideoTracks != null) {
@@ -997,12 +998,12 @@ class ReactExoplayerView extends FrameLayout implements
         WritableArray videoTracks = Arguments.createArray();
 
         MappingTrackSelector.MappedTrackInfo info = trackSelector.getCurrentMappedTrackInfo();
-        int index = getTrackRendererIndex(C.TRACK_TYPE_VIDEO);
-        if (info == null || index == C.INDEX_UNSET) {
+        
+        if (info == null || trackRendererIndex == C.INDEX_UNSET) {
             return videoTracks;
         }
 
-        TrackGroupArray groups = info.getTrackGroups(index);
+        TrackGroupArray groups = info.getTrackGroups(trackRendererIndex);
         for (int i = 0; i < groups.length; ++i) {
             TrackGroup group = groups.get(i);
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -945,6 +945,7 @@ class ReactExoplayerView extends FrameLayout implements
             int height = videoFormat != null ? videoFormat.height : 0;
             String trackId = videoFormat != null ? videoFormat.id : "-1";
 
+            // Properties that must be accessed on the main thread
             long duration = player.getDuration();
             long currentPosition = player.getCurrentPosition();
             WritableArray audioTrackInfo = getAudioTrackInfo();
@@ -954,9 +955,9 @@ class ReactExoplayerView extends FrameLayout implements
 
             ExecutorService es = Executors.newSingleThreadExecutor();
             es.execute(new Runnable() {
-
                 @Override
                 public void run() {
+                    // To prevent ANRs caused by getVideoTrackInfo we run this on a different thread and notify the player only when we're done
                     eventEmitter.load(duration, currentPosition, width, height,
                         audioTrackInfo, textTrackInfo, getVideoTrackInfo(timelineRef, trackRendererIndex), trackId);
                 }
@@ -1042,7 +1043,6 @@ class ReactExoplayerView extends FrameLayout implements
 
             public WritableArray call() throws Exception {
                 WritableArray videoTracks = Arguments.createArray();
-                Thread.sleep(3500);
                 try  {
                     DashManifest manifest = DashUtil.loadManifest(this.ds, this.uri);
                     int periodCount = manifest.getPeriodCount();


### PR DESCRIPTION
JIRA: [VEX-6778](https://jira.tenkasu.net/browse/VEX-6778) 

Move video track info request logic entirely on a different thread, completely preventing ANRs in this section of code.