### PR TITLE
VEX-6779: React Native Video buildDrmSessionManager crash

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -560,8 +560,8 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void initializePlayerCore(ReactExoplayerView self) {
         ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
-        trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
-        trackSelector.setParameters(trackSelector.buildUponParameters()
+        self.trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
+        self.trackSelector.setParameters(self.trackSelector.buildUponParameters()
                 .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
 
         DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
@@ -579,21 +579,21 @@ class ReactExoplayerView extends FrameLayout implements
         DefaultRenderersFactory renderersFactory =
                 new DefaultRenderersFactory(getContext())
                         .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
-        player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
+        self.player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
                     .setTrackSelector​(trackSelector)
                     .setBandwidthMeter(bandwidthMeter)
                     .setLoadControl(loadControl)
                     .build();
-        player.addListener(self);
-        player.addMetadataOutput(self);
-        exoPlayerView.setPlayer(player);
-        audioBecomingNoisyReceiver.setListener(self);
-        bandwidthMeter.addEventListener(new Handler(), self);
+        self.player.addListener(self);
+        self.player.addMetadataOutput(self);
+        self.exoPlayerView.setPlayer(player);
+        self.audioBecomingNoisyReceiver.setListener(self);
+        self.bandwidthMeter.addEventListener(new Handler(), self);
         setPlayWhenReady(!isPaused);
-        playerNeedsSource = true;
+        self.playerNeedsSource = true;
 
         PlaybackParameters params = new PlaybackParameters(rate, 1f);
-        player.setPlaybackParameters(params);
+        self.player.setPlaybackParameters(params);
     }
 
     private DrmSessionManager initializePlayerDrm(ReactExoplayerView self) {
@@ -615,7 +615,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void initializePlayerSource(ReactExoplayerView self, DrmSessionManager drmSessionManager) {
         ArrayList<MediaSource> mediaSourceList = buildTextSources();
-        MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
+        MediaSource videoSource = self.buildMediaSource(self.srcUri, self.extension, drmSessionManager);
         MediaSource mediaSource;
         if (mediaSourceList.size() == 0) {
             mediaSource = videoSource;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -500,6 +500,9 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void stopBufferCheckTimer() {
+        if (this.bufferCheckTimer == null) {
+            return;
+        }
         this.bufferCheckTimer.cancel();
         this.bufferCheckTimer = null;
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -537,13 +537,13 @@ class ReactExoplayerView extends FrameLayout implements
                                     @Override
                                     public void run () {
                                         // Source initialization must run on the main thread
-                                        initializePlayerSource(self, drmSessionManager);
+                                        initializePlayerSource(self, drmSessionManager, srcUri);
                                     }
                                 });
                             }
                         });
                     } else {
-                        initializePlayerSource(self, null);
+                        initializePlayerSource(self, null, srcUri);
                     }
                     
                 
@@ -613,9 +613,9 @@ class ReactExoplayerView extends FrameLayout implements
         return drmSessionManager;
     }
 
-    private void initializePlayerSource(ReactExoplayerView self, DrmSessionManager drmSessionManager) {
+    private void initializePlayerSource(ReactExoplayerView self, DrmSessionManager drmSessionManager, Uri srcUri) {
         ArrayList<MediaSource> mediaSourceList = buildTextSources();
-        MediaSource videoSource = self.buildMediaSource(self.srcUri, self.extension, drmSessionManager);
+        MediaSource videoSource = self.buildMediaSource(srcUri, self.extension, drmSessionManager);
         MediaSource mediaSource;
         if (mediaSourceList.size() == 0) {
             mediaSource = videoSource;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -524,7 +524,7 @@ class ReactExoplayerView extends FrameLayout implements
                             @Override
                             public void run() {
                                 // DRM initialization must run on a different thread
-                                DRMSessionManager drmSessionManager = initializePlayerDrm(self);
+                                DrmSessionManager drmSessionManager = initializePlayerDrm(self);
                                 if (drmSessionManager == null) {
                                     // Failed to intialize DRM session manager - cannot continue
                                     return;
@@ -644,6 +644,10 @@ class ReactExoplayerView extends FrameLayout implements
         setControls(controls);
         applyModifiers();
         startBufferCheckTimer();
+    }
+
+    private DrmSessionManager buildDrmSessionManager(UUID uuid, String licenseUrl, String[] keyRequestPropertiesArray) throws UnsupportedDrmException {
+        return buildDrmSessionManager(uuid, licenseUrl, keyRequestPropertiesArray, 0);
     }
 
     private DrmSessionManager buildDrmSessionManager(UUID uuid, String licenseUrl, String[] keyRequestPropertiesArray, int retryCount) throws UnsupportedDrmException {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -537,13 +537,13 @@ class ReactExoplayerView extends FrameLayout implements
                                     @Override
                                     public void run () {
                                         // Source initialization must run on the main thread
-                                        initializePlayerSource(self, drmSessionManager, srcUri);
+                                        initializePlayerSource(self, drmSessionManager);
                                     }
                                 });
                             }
                         });
-                    } else {
-                        initializePlayerSource(self, null, srcUri);
+                    } else if (srcUri != null) {
+                        initializePlayerSource(self, null);
                     }
                     
                 
@@ -560,8 +560,8 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void initializePlayerCore(ReactExoplayerView self) {
         ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
-        self.trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
-        self.trackSelector.setParameters(self.trackSelector.buildUponParameters()
+        trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
+        trackSelector.setParameters(trackSelector.buildUponParameters()
                 .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
 
         DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
@@ -579,21 +579,21 @@ class ReactExoplayerView extends FrameLayout implements
         DefaultRenderersFactory renderersFactory =
                 new DefaultRenderersFactory(getContext())
                         .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
-        self.player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
+        player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
                     .setTrackSelector​(trackSelector)
                     .setBandwidthMeter(bandwidthMeter)
                     .setLoadControl(loadControl)
                     .build();
-        self.player.addListener(self);
-        self.player.addMetadataOutput(self);
-        self.exoPlayerView.setPlayer(player);
-        self.audioBecomingNoisyReceiver.setListener(self);
-        self.bandwidthMeter.addEventListener(new Handler(), self);
+        player.addListener(self);
+        player.addMetadataOutput(self);
+        exoPlayerView.setPlayer(player);
+        audioBecomingNoisyReceiver.setListener(self);
+        bandwidthMeter.addEventListener(new Handler(), self);
         setPlayWhenReady(!isPaused);
-        self.playerNeedsSource = true;
+        playerNeedsSource = true;
 
         PlaybackParameters params = new PlaybackParameters(rate, 1f);
-        self.player.setPlaybackParameters(params);
+        player.setPlaybackParameters(params);
     }
 
     private DrmSessionManager initializePlayerDrm(ReactExoplayerView self) {
@@ -613,9 +613,9 @@ class ReactExoplayerView extends FrameLayout implements
         return drmSessionManager;
     }
 
-    private void initializePlayerSource(ReactExoplayerView self, DrmSessionManager drmSessionManager, Uri srcUri) {
+    private void initializePlayerSource(ReactExoplayerView self, DrmSessionManager drmSessionManager) {
         ArrayList<MediaSource> mediaSourceList = buildTextSources();
-        MediaSource videoSource = self.buildMediaSource(srcUri, self.extension, drmSessionManager);
+        MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
         MediaSource mediaSource;
         if (mediaSourceList.size() == 0) {
             mediaSource = videoSource;


### PR DESCRIPTION
Move DRM initialization logic into a separate thread to prevent ANRs.

JIRA: VEX-6779
https://jira.tenkasu.net/browse/VEX-6779
