### PR TITLE
VEX-6350: add onPlaybackStateChanged prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ var styles = StyleSheet.create({
 * [onFullscreenPlayerDidDismiss](#onfullscreenplayerdiddismiss)
 * [onLoad](#onload)
 * [onLoadStart](#onloadstart)
+* [onPlaybackStateChanged]($onPlaybackStateChanged)
 * [onReadyForDisplay](#onreadyfordisplay)
 * [onPictureInPictureStatusChanged](#onpictureinpicturestatuschanged)
 * [onPlaybackRateChange](#onplaybackratechange)
@@ -1109,6 +1110,24 @@ Example:
 ```
 
 Platforms: all
+
+#### onPlaybackStateChanged
+Callback function that is called when the playback state changes.
+
+Payload:
+
+Property | Description
+--- | ---
+isPlaying | boolean | Boolean indicating if the media is playing or not
+
+Example:
+```
+{
+  isPlaying: true,
+}
+```
+
+Platforms: Android ExoPlayer
 
 #### onReadyForDisplay
 Callback function that is called when the first video frame is ready for display. This is when the poster is removed.

--- a/Video.js
+++ b/Video.js
@@ -99,6 +99,12 @@ export default class Video extends Component {
     }
   };
 
+  _onPlaybackStateChanged = (event) => {
+    if (this.props.onPlaybackStateChanged) {
+      this.props.onPlaybackStateChanged(event.nativeEvent);
+    }
+  };
+
   _onLoad = (event) => {
     // Need to hide poster here for windows as onReadyForDisplay is not implemented
     if (Platform.OS === 'windows') {
@@ -311,6 +317,7 @@ export default class Video extends Component {
         requestHeaders: source.headers ? this.stringsOnlyObject(source.headers) : {},
       },
       onVideoLoadStart: this._onLoadStart,
+      onVideoPlaybackStateChanged: this._onPlaybackStateChanged,
       onVideoLoad: this._onLoad,
       onVideoError: this._onError,
       onVideoProgress: this._onProgress,
@@ -491,6 +498,7 @@ Video.propTypes = {
   useSecureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,
+  onPlaybackStateChanged: PropTypes.func,
   onLoad: PropTypes.func,
   onBuffer: PropTypes.func,
   onError: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1244,6 +1244,11 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     @Override
+    public void onIsPlayingChanged(boolean isPlaying) {
+        eventEmitter.playbackStateChanged(isPlaying);
+    }
+
+    @Override
     public void onPlayerError(ExoPlaybackException e) {
         String errorString = "ExoPlaybackException type : " + e.type;
         String errorCode = "2001"; // Playback error code 2xxx (2001 - unknown playback exception)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -44,6 +44,7 @@ class VideoEventEmitter {
     private static final String EVENT_RESUME = "onPlaybackResume";
     private static final String EVENT_READY = "onReadyForDisplay";
     private static final String EVENT_BUFFER = "onVideoBuffer";
+    private static final String EVENT_PLAYBACK_STATE_CHANGED = "onVideoPlaybackStateChanged";
     private static final String EVENT_BUFFER_PROGRESS = "onVideoBufferProgress";
     private static final String EVENT_IDLE = "onVideoIdle";
     private static final String EVENT_TIMED_METADATA = "onTimedMetadata";
@@ -66,6 +67,7 @@ class VideoEventEmitter {
             EVENT_RESUME,
             EVENT_READY,
             EVENT_BUFFER,
+            EVENT_PLAYBACK_STATE_CHANGED,
             EVENT_BUFFER_PROGRESS,
             EVENT_IDLE,
             EVENT_TIMED_METADATA,
@@ -91,6 +93,7 @@ class VideoEventEmitter {
             EVENT_RESUME,
             EVENT_READY,
             EVENT_BUFFER,
+            EVENT_PLAYBACK_STATE_CHANGED,
             EVENT_BUFFER_PROGRESS,
             EVENT_IDLE,
             EVENT_TIMED_METADATA,
@@ -137,8 +140,9 @@ class VideoEventEmitter {
 
     private static final String EVENT_PROP_TIMED_METADATA = "metadata";
 
-    private static final String EVENT_PROP_BITRATE = "bitrate";   
+    private static final String EVENT_PROP_BITRATE = "bitrate";
 
+    private static final String EVENT_PROP_IS_PLAYING = "isPlaying";
 
     void setViewId(int viewId) {
         this.viewId = viewId;
@@ -213,6 +217,12 @@ class VideoEventEmitter {
         WritableMap map = Arguments.createMap();
         map.putBoolean(EVENT_PROP_IS_BUFFERING, isBuffering);
         receiveEvent(EVENT_BUFFER, map);
+    }
+
+    void playbackStateChanged(boolean isPlaying) {
+        WritableMap map = Arguments.createMap();
+        map.putBoolean(EVENT_PROP_IS_PLAYING, isPlaying);
+        receiveEvent(EVENT_PLAYBACK_STATE_CHANGED, map);
     }
 
     void bufferProgress(double start, double end) {


### PR DESCRIPTION
This PR adds the new prop `onPlaybackStateChanged`

Velocity PR: https://github.com/crunchyroll/velocity/pull/2401

Jira: VEX-6350

Using the new prop from `react-native-video` we can know the current state of the player, which helps us identify if the player state is out of sync with the player state caused by an external pause (described in the ticket) the code is simple if the player reports it's stopped and velocity's state reports it's playing, sync the states to the value of the player.

### Reviews
- Major reviewer (domain expert): @armadilio3 
- Minor reviewer: @jctorresM 
### PR Checklist
- [x] Unit tests have been written
- [x] Documentation has been created and/or updated

### Testing instructions

**Android mobile**

Test harness: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-6350-pause-video-when-externally-paused/android-mobile/android-app-debug.apk

Client app: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-6350-pause-video-when-externally-paused/androidmobile-client/etp-android-debug.apk

```
1. Execute yarn start-androidmobile
2. Play any video
3. Start split-screen
4. Select Youtube as the second app
5. Play any video in youtube
6. Confirm the video pauses on test-harness when the video starts playing in Youtube
7. Confirm that bringing up the video controls in test-harness play button is displayed
8. Press play button in test-harness
9. Confirm the video starts playing in test-harness and Youtube app pauses
```