### PR TITLE
VEX-6099: Android: Progress knob jumps backward after tapping Skip Forwards multiple times

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1206,21 +1206,23 @@ class ReactExoplayerView extends FrameLayout implements
                 && player.getRepeatMode() == Player.REPEAT_MODE_ONE) {
             eventEmitter.end();
         }
+
+    }
+
+    @Override onPlaybackStateChanged(int playbackState) {
+        if (state == Player.STATE_READY && seekTime != C.TIME_UNSET) {
+            eventEmitter.seek(player.getCurrentPosition(), seekTime);
+            seekTime = C.TIME_UNSET;
+            if (isUsingContentResolution) {
+                // We need to update the selected track to make sure that it still matches user selection if track list has changed in this period
+                setSelectedTrack(C.TRACK_TYPE_VIDEO, videoTrackType, videoTrackValue);
+            }
+        }
     }
 
     @Override
     public void onTimelineChanged(Timeline timeline, Object manifest, int reason) {
         // Do nothing.
-    }
-
-    @Override
-    public void onSeekProcessed() {
-        eventEmitter.seek(player.getCurrentPosition(), seekTime);
-        seekTime = C.TIME_UNSET;
-        if (isUsingContentResolution) {
-            // We need to update the selected track to make sure that it still matches user selection if track list has changed in this period
-            setSelectedTrack(C.TRACK_TYPE_VIDEO, videoTrackType, videoTrackValue);
-        }
     }
 
     @Override

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1209,7 +1209,8 @@ class ReactExoplayerView extends FrameLayout implements
 
     }
 
-    @Override onPlaybackStateChanged(int playbackState) {
+    @Override
+    void onPlaybackStateChanged(int playbackState) {
         if (state == Player.STATE_READY && seekTime != C.TIME_UNSET) {
             eventEmitter.seek(player.getCurrentPosition(), seekTime);
             seekTime = C.TIME_UNSET;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1210,7 +1210,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     @Override
-    void onPlaybackStateChanged(int playbackState) {
+    public void onPlaybackStateChanged(int playbackState) {
         if (playbackState == Player.STATE_READY && seekTime != C.TIME_UNSET) {
             eventEmitter.seek(player.getCurrentPosition(), seekTime);
             seekTime = C.TIME_UNSET;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1211,7 +1211,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     void onPlaybackStateChanged(int playbackState) {
-        if (state == Player.STATE_READY && seekTime != C.TIME_UNSET) {
+        if (playbackState == Player.STATE_READY && seekTime != C.TIME_UNSET) {
             eventEmitter.seek(player.getCurrentPosition(), seekTime);
             seekTime = C.TIME_UNSET;
             if (isUsingContentResolution) {


### PR DESCRIPTION
Move to the new way of detecting seek end and remove `onSeekProcessed` which was deprecated.

JIRA: VEX-6099 