### PR TITLE
VEX-6891: Android: Infinite loading when closing & reopening the player on low end devices

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -34,6 +34,7 @@ import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.drm.MediaDrmCallbackException;
+import com.google.android.exoplayer2.drm.DrmSession.DrmSessionException;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.PlaybackParameters;
@@ -1291,7 +1292,7 @@ class ReactExoplayerView extends FrameLayout implements
             if (cause instanceof DefaultDrmSessionManager.MissingSchemeDataException) {
                 errorCode = "3004";
                 errorString = getResources().getString(R.string.unrecognized_media_format);
-            } else if(cause instanceof MediaDrmCallbackException) {
+            } else if(cause instanceof MediaDrmCallbackException || cause instanceof DrmSessionException) {
                 errorCode = "3005";
                 errorString = getResources().getString(R.string.unrecognized_media_format);
                 if (!hasDrmFailed) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1301,6 +1301,7 @@ class ReactExoplayerView extends FrameLayout implements
                     playerNeedsSource = true;
                     updateResumePosition();
                     initializePlayer();
+                    setPlayWhenReady(true)
                     return;
                 }
             } else {
@@ -1318,6 +1319,7 @@ class ReactExoplayerView extends FrameLayout implements
                         playerNeedsSource = true;
                         updateResumePosition();
                         initializePlayer();
+                        setPlayWhenReady(true)
                         return;
                     }
                 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1301,7 +1301,7 @@ class ReactExoplayerView extends FrameLayout implements
                     playerNeedsSource = true;
                     updateResumePosition();
                     initializePlayer();
-                    setPlayWhenReady(true)
+                    setPlayWhenReady(true);
                     return;
                 }
             } else {
@@ -1319,7 +1319,7 @@ class ReactExoplayerView extends FrameLayout implements
                         playerNeedsSource = true;
                         updateResumePosition();
                         initializePlayer();
-                        setPlayWhenReady(true)
+                        setPlayWhenReady(true);
                         return;
                     }
                 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1374,7 +1374,8 @@ class ReactExoplayerView extends FrameLayout implements
     public void setSrc(final Uri uri, final String extension, Map<String, String> headers) {
         if (uri != null) {
             boolean isSourceEqual = uri.equals(srcUri);
-
+            
+            hasDrmFailed = false;
             this.srcUri = uri;
             this.extension = extension;
             this.requestHeaders = headers;


### PR DESCRIPTION
On low end devices when replaying same content too quickly DRM could fail with an uncaptured error (`DrmSessionException`). To prevent this we now check for that error and retry DRM one more time.