### PR TITLE
VEX-6625: Handle state to keep playing after gaining connection

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -803,15 +803,9 @@ class ReactExoplayerView extends FrameLayout implements
     private void startPlayback() {
         if (player != null) {
             switch (player.getPlaybackState()) {
+                case Player.STATE_IDLE:
                 case Player.STATE_ENDED:
                     initializePlayer();
-                    break;
-                case Player.STATE_IDLE:
-                    initializePlayer();
-                    if (!player.getPlayWhenReady()) {
-                        setPlayWhenReady(true);
-                    }
-                    break;
                 case Player.STATE_BUFFERING:
                 case Player.STATE_READY:
                     if (!player.getPlayWhenReady()) {
@@ -821,7 +815,6 @@ class ReactExoplayerView extends FrameLayout implements
                 default:
                     break;
             }
-
         } else {
             initializePlayer();
         }
@@ -1307,6 +1300,12 @@ class ReactExoplayerView extends FrameLayout implements
                     initializePlayer();
                     return;
                 }
+            } else if (cause instanceof HttpDataSource.HttpDataSourceException) {
+                // this exception happens when connectivity is lost
+                updateResumePosition();
+                initializePlayer();
+                setPlayWhenReady(true);
+                return;
             } else {
                 errorCode = "2021";
                 errorString = getResources().getString(R.string.unrecognized_media_format);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -803,9 +803,14 @@ class ReactExoplayerView extends FrameLayout implements
     private void startPlayback() {
         if (player != null) {
             switch (player.getPlaybackState()) {
-                case Player.STATE_IDLE:
                 case Player.STATE_ENDED:
                     initializePlayer();
+                    break;
+                case Player.STATE_IDLE:
+                    initializePlayer();
+                    if (!player.getPlayWhenReady()) {
+                        setPlayWhenReady(true);
+                    }
                     break;
                 case Player.STATE_BUFFERING:
                 case Player.STATE_READY:


### PR DESCRIPTION
This PR handles autoplay after disconnection

Jira: VEX-6625

There was an error in react-native-video not being properly handled, in addition, the state of the player when reconnecting using a free user was not the expected one, requesting the player to keep playing when ready, made the behavior consistent in all scenarios

Velocity PR: https://github.com/crunchyroll/velocity/pull/2430

### Reviews

- Major reviewer (domain expert): @jctorresM
- Minor reviewer: @jacob-livingston 

### PR Checklist

- [/] Unit tests have been written
- [/] Documentation has been created and/or updated

### Testing instructions

#### Android mobile

Test harness: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-6625-ensure-free-user-enabling-cellular-continues-playing/android-mobile/android-app-debug.apk

Client app: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-6625-ensure-free-user-enabling-cellular-continues-playing/androidmobile-client/etp-android-debug.apk

##### Android mobile phone

```
Scenario 1
1. Use a device with wifi + cellular
2. Install the client application or run yarn start-androidmobile-client --clean
3. Login with a free user
4. Enable V2 at config delta override
5. Disable steam using cellular
6. Play an episode
7. After the ads, disconnect wifi
8. Wait for the buffer to run out
9. Select yes use cellular on the popup
10. Confirm the episode keeps playing without restarting
Scenario 2
11. Reconnect wifi
12. Let it play for a moment to fill the buffer a bit
13. Disconnect cellular
14. Disconnect wifi
15. When buffer runs out, if the player gets black continue with the steps, otherwise go back to step 11
16. Reconnect wifi
17. Confirm the episode continues playing from the previous time
```