### PR TITLE
VEX-7093: Protect initialization of DRM

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -632,6 +632,16 @@ class ReactExoplayerView extends FrameLayout implements
             mediaSource = new MergingMediaSource(textSourceArray);
         }
 
+        // wait for player to be set
+        while (player == null) {
+            try {
+                wait();
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                Log.e("ExoPlayer Exception", ex.toString());
+            }
+        }
+
         boolean haveResumePosition = resumeWindow != C.INDEX_UNSET;
         if (haveResumePosition) {
             player.seekTo(resumeWindow, resumePosition);


### PR DESCRIPTION
This PR will fix the crash from the experiment on `react-native-video`

Jira: VEX-7093

velocity PR: https://github.com/crunchyroll/velocity/pull/2443

The crash was caused by using the player object before it was set by another thread, the change simply waits for the player to be available before executing any player interaction after DRM initialization.

### Reviews

- Major reviewer (domain expert): @jctorresM 
- Minor reviewer: @jacob-livingston 

### PR Checklist

- [ ] Unit tests have been written
- [ ] Documentation has been created and/or updated

### Testing instructions

#### Web

#### Android mobile

Test harness: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-7093-crash-in-exoplayer/android-mobile/android-app-debug.apk

Client app: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-7093-crash-in-exoplayer/androidmobile-client/etp-android-debug.apk

##### Android mobile phone & tablet, use different Android versions to confirm

```
1. Execute yarn start-androidmobile-client --clean
2. Play a video
3. Make sure the video plays as expected
```
