### PR TITLE
VEX-7094: Android: Crash in ReactExoplayerView.java Line 694

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -708,10 +708,10 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private MediaSource buildMediaSource(Uri uri, String overrideExtension, DrmSessionManager drmSessionManager) {
-        // if (uri == null) {
+        if (uri == null) {
             throw new IllegalStateException("Invalid video uri");
-        // }
-       /* int type = Util.inferContentType(!TextUtils.isEmpty(overrideExtension) ? "." + overrideExtension
+        }
+        int type = Util.inferContentType(!TextUtils.isEmpty(overrideExtension) ? "." + overrideExtension
                 : uri.getLastPathSegment());
         config.setDisableDisconnectError(this.disableDisconnectError);
         switch (type) {
@@ -748,7 +748,7 @@ class ReactExoplayerView extends FrameLayout implements
             default: {
                 throw new IllegalStateException("Unsupported type: " + type);
             }
-        }*/
+        }
     }
 
     private ArrayList<MediaSource> buildTextSources() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -541,14 +541,11 @@ class ReactExoplayerView extends FrameLayout implements
                                 activity.runOnUiThread(new Runnable() {
                                     public void run() {
                                         try {
-                                            Log.w("Velocity", "DEBUG1");
                                             // Source initialization must run on the main thread
                                             initializePlayerSource(self, drmSessionManager);
-                                            Log.w("Velocity", "DEBUG2");
                                         } catch (Exception ex) {
-                                            Log.w("Velocity", "DEBUG3");
                                             self.playerNeedsSource = true;
-                                            Log.e("ExoPlayer Exception", "Failed to initialize Player source!");
+                                            Log.e("ExoPlayer Exception", "Failed to initialize Player!");
                                             Log.e("ExoPlayer Exception", ex.toString());
                                             self.eventEmitter.error(ex.toString(), ex, "1001");
                                         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -711,7 +711,7 @@ class ReactExoplayerView extends FrameLayout implements
         // if (uri == null) {
             throw new IllegalStateException("Invalid video uri");
         // }
-        int type = Util.inferContentType(!TextUtils.isEmpty(overrideExtension) ? "." + overrideExtension
+       /* int type = Util.inferContentType(!TextUtils.isEmpty(overrideExtension) ? "." + overrideExtension
                 : uri.getLastPathSegment());
         config.setDisableDisconnectError(this.disableDisconnectError);
         switch (type) {
@@ -748,7 +748,7 @@ class ReactExoplayerView extends FrameLayout implements
             default: {
                 throw new IllegalStateException("Unsupported type: " + type);
             }
-        }
+        }*/
     }
 
     private ArrayList<MediaSource> buildTextSources() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -708,9 +708,9 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private MediaSource buildMediaSource(Uri uri, String overrideExtension, DrmSessionManager drmSessionManager) {
-        if (uri == null) {
+        // if (uri == null) {
             throw new IllegalStateException("Invalid video uri");
-        }
+        // }
         int type = Util.inferContentType(!TextUtils.isEmpty(overrideExtension) ? "." + overrideExtension
                 : uri.getLastPathSegment());
         config.setDisableDisconnectError(this.disableDisconnectError);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -540,8 +540,15 @@ class ReactExoplayerView extends FrameLayout implements
                                 // Initialize handler to run on the main thread
                                 activity.runOnUiThread(new Runnable() {
                                     public void run() {
-                                        // Source initialization must run on the main thread
-                                        initializePlayerSource(self, drmSessionManager);
+                                        try {
+                                            // Source initialization must run on the main thread
+                                            initializePlayerSource(self, drmSessionManager);
+                                        } catch (Exception ex) {
+                                            self.playerNeedsSource = true;
+                                            Log.e("ExoPlayer Exception", "Failed to initialize Player source!");
+                                            Log.e("ExoPlayer Exception", ex.toString());
+                                            eventEmitter.error(ex.toString(), ex, "1002");
+                                        }
                                     }
                                 });
                             }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -541,13 +541,16 @@ class ReactExoplayerView extends FrameLayout implements
                                 activity.runOnUiThread(new Runnable() {
                                     public void run() {
                                         try {
+                                            Log.w("Velocity", "DEBUG1");
                                             // Source initialization must run on the main thread
                                             initializePlayerSource(self, drmSessionManager);
+                                            Log.w("Velocity", "DEBUG2");
                                         } catch (Exception ex) {
+                                            Log.w("Velocity", "DEBUG3");
                                             self.playerNeedsSource = true;
                                             Log.e("ExoPlayer Exception", "Failed to initialize Player source!");
                                             Log.e("ExoPlayer Exception", ex.toString());
-                                            eventEmitter.error(ex.toString(), ex, "1002");
+                                            self.eventEmitter.error(ex.toString(), ex, "1001");
                                         }
                                     }
                                 });
@@ -627,7 +630,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void initializePlayerSource(ReactExoplayerView self, DrmSessionManager drmSessionManager) {
         ArrayList<MediaSource> mediaSourceList = buildTextSources();
-        MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
+        MediaSource videoSource = buildMediaSource(self.srcUri, self.extension, drmSessionManager);
         MediaSource mediaSource;
         if (mediaSourceList.size() == 0) {
             mediaSource = videoSource;


### PR DESCRIPTION
When moving init logic to a different thread we missed one function that was not captured if an error occurred. This PR wraps the source init function that happens on a different thread in a try/catch to capture any errors that occur.