### PR TITLE
VEX-7095: Crash in ReactExoplayerView.java Line 1059

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -571,8 +571,8 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void initializePlayerCore(ReactExoplayerView self) {
         ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
-        trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
-        trackSelector.setParameters(trackSelector.buildUponParameters()
+        self.trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
+        self.trackSelector.setParameters(trackSelector.buildUponParameters()
                 .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
 
         DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
@@ -591,7 +591,7 @@ class ReactExoplayerView extends FrameLayout implements
                 new DefaultRenderersFactory(getContext())
                         .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
         player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
-                    .setTrackSelector​(trackSelector)
+                    .setTrackSelector​(self.trackSelector)
                     .setBandwidthMeter(bandwidthMeter)
                     .setLoadControl(loadControl)
                     .build();
@@ -1041,6 +1041,11 @@ class ReactExoplayerView extends FrameLayout implements
 
     private WritableArray getAudioTrackInfo() {
         WritableArray audioTracks = Arguments.createArray();
+
+        if (trackSelector = null) {
+            // Likely player is unmounting so no audio tracks are available anymore
+            return audioTracks;
+        }
 
         MappingTrackSelector.MappedTrackInfo info = trackSelector.getCurrentMappedTrackInfo();
         int index = getTrackRendererIndex(C.TRACK_TYPE_AUDIO);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1042,7 +1042,7 @@ class ReactExoplayerView extends FrameLayout implements
     private WritableArray getAudioTrackInfo() {
         WritableArray audioTracks = Arguments.createArray();
 
-        if (trackSelector = null) {
+        if (trackSelector == null) {
             // Likely player is unmounting so no audio tracks are available anymore
             return audioTracks;
         }


### PR DESCRIPTION
Prevent crashing when track selector is null.

JIRA: VEX-7095
https://jira.tenkasu.net/browse/VEX-7095
