### PR TITLE
VEX-7430: Add null checks to trackSelector

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1118,8 +1118,15 @@ class ReactExoplayerView extends FrameLayout implements
 
         WritableArray videoTracks = Arguments.createArray();
 
+        if (trackSelector == null) {
+            // The player is probably unmounting, the only entry point to this method
+            // is trough onPlayerStateChanged when Player.STATE_READY which means
+            // if trackSelector is null, the player is most likely cleaning up
+            return videoTracks;
+        }
+
         MappingTrackSelector.MappedTrackInfo info = trackSelector.getCurrentMappedTrackInfo();
-        
+
         if (info == null || trackRendererIndex == C.INDEX_UNSET) {
             return videoTracks;
         }
@@ -1280,6 +1287,11 @@ class ReactExoplayerView extends FrameLayout implements
 
     private WritableArray getTextTrackInfo() {
         WritableArray textTracks = Arguments.createArray();
+
+        if (trackSelector == null) {
+            // Likely player is unmounting so no text tracks are available anymore
+            return textTracks;
+        }
 
         MappingTrackSelector.MappedTrackInfo info = trackSelector.getCurrentMappedTrackInfo();
         int index = getTrackRendererIndex(C.TRACK_TYPE_TEXT);


### PR DESCRIPTION
This PR adds null checks to `trackSelector` that was causing a crash

Jira: VEX-7430

Velocity PR: https://github.com/crunchyroll/velocity/pull/2535

As part of the Velocity rollout, one of the crashes unveiled was on `react-native-video`:`1121`
The crash was caused by the instance `trackSelector` being `null` which happens either at the start of the process or when `releasePlayer()` is invoked, since the only entry point was through an event that only gets registered when we have a valid player, it means this crash happened when the player was being released. Having that in mind, there's no need to retrieve valid video tracks and it's safe to just return an empty `WritableArray`

The crash happened on multiple devices with no specific Android version

### Reviews

- Major reviewer (domain expert): @armadilio3 
- Minor reviewer: @bbcawodu 

### PR Checklist

- [/] Unit tests have been written
- [x] Documentation has been created and/or updated

### Testing instructions

#### Android mobile

Test harness: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-7430-add-null-checks-to-1121/android-mobile/android-app-debug.apk

Client app: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-7430-add-null-checks-to-1121/androidmobile-client/etp-android-debug.apk

```
1. Execute yarn start-androidmobile-client --clean
2. Play any video
```
