### PR TITLE
VEX-7817: Prevent exception on getVideoTrackInfo

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -240,7 +240,6 @@ class ReactExoplayerView extends FrameLayout implements
         this.eventEmitter = new VideoEventEmitter(context);
         this.config = config;
         this.bandwidthMeter = config.getBandwidthMeter();
-
         createViews();
 
         audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
@@ -1074,9 +1073,13 @@ class ReactExoplayerView extends FrameLayout implements
         }
 
         WritableArray videoTracks = Arguments.createArray();
+        if (trackSelector == null) {
+            // player is unmounting so no video tracks are available anymore
+            return videoTracks;
+        }
 
         MappingTrackSelector.MappedTrackInfo info = trackSelector.getCurrentMappedTrackInfo();
-        
+
         if (info == null || trackRendererIndex == C.INDEX_UNSET) {
             return videoTracks;
         }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "deprecated-react-native-prop-types": "^2.2.0",
         "keymirror": "^0.1.1",
         "prop-types": "^15.7.2",
-        "shaka-player": "^3.3.2"
+        "shaka-player": "^2.5.9"
     },
     "scripts": {
         "lint": "yarn eslint .",


### PR DESCRIPTION
This PR fixes the exception found in Crashlytics for 3.24

Jira: VEX-7817

Velocity PR: https://github.com/crunchyroll/velocity/pull/2647

There was a crash on line 1078 where `trackSelector` is null at the time of destroying the player, to contain the exception the video tracks are returned as an empty list if `trackSelector` is null.

### Reviews

- Major reviewer (domain expert): @adrian-hammers 
- Minor reviewer: @jacob-livingston 

### PR Checklist

- [/] Unit tests have been written
- [/] Documentation has been created and/or updated

### Testing instructions

#### Android mobile

Test harness: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-7817-exception-on-1078/android-mobile/android-app-debug.apk

Client app: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-7817-exception-on-1078/androidmobile-client/etp-android-debug.apk

##### Android mobile phone

```
1. yarn start-androidmobile-client
2. play any video
3. load the next video
4. confirm there are no exceptions
```
