### PR TITLE
VEX-7847: add info to errors

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -58,7 +58,11 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.source.BehindLiveWindowException;
+import com.google.android.exoplayer2.source.LoadEventInfo;
+import com.google.android.exoplayer2.source.MediaLoadData;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.MediaSource.MediaPeriodId;
+import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.source.MergingMediaSource;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.source.SingleSampleMediaSource;
@@ -91,6 +95,7 @@ import com.google.android.exoplayer2.source.dash.manifest.AdaptationSet;
 import com.google.android.exoplayer2.source.dash.manifest.Representation;
 import com.google.android.exoplayer2.source.dash.manifest.Descriptor;
 
+import java.io.IOException;
 import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
@@ -139,6 +144,7 @@ class ReactExoplayerView extends FrameLayout implements
     private PlayerControlView playerControlView;
     private View playPauseControlContainer;
     private Player.Listener eventListener;
+    private MediaSourceEventListener mediaSourceEventListener;
 
     private ExoPlayerView exoPlayerView;
 
@@ -173,6 +179,7 @@ class ReactExoplayerView extends FrameLayout implements
     private double minBackBufferMemoryReservePercent = ReactExoplayerView.DEFAULT_MIN_BACK_BUFFER_MEMORY_RESERVE;
     private double minBufferMemoryReservePercent = ReactExoplayerView.DEFAULT_MIN_BUFFER_MEMORY_RESERVE;
     private Handler mainHandler;
+    public List<Segment> segments;
 
     // Props from React
     private int backBufferDurationMs = DefaultLoadControl.DEFAULT_BACK_BUFFER_DURATION_MS;
@@ -245,6 +252,8 @@ class ReactExoplayerView extends FrameLayout implements
         audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         themedReactContext.addLifecycleEventListener(this);
         audioBecomingNoisyReceiver = new AudioBecomingNoisyReceiver(themedReactContext);
+        this.mediaSourceEventListener = new MediaSourceListener();
+        this.segments = new ArrayList<Segment>();
     }
 
 
@@ -481,6 +490,39 @@ class ReactExoplayerView extends FrameLayout implements
         }
     }
 
+    /**
+     * class that holds the data of a segment loaded
+     */
+    private final class Segment {
+        public long mediaStartTimeMs;
+        public long mediaEndTimeMs;
+        public Uri uri;
+        Segment(long mediaEndTimeMs, long mediaStartTimeMs, Uri uri){
+            this.mediaEndTimeMs = mediaEndTimeMs;
+            this.mediaStartTimeMs = mediaStartTimeMs;
+            this.uri = uri;
+        }
+    }
+
+    /**
+     * class that listens the events of segments being loaded
+     */
+    private final class MediaSourceListener implements MediaSourceEventListener {
+        @Override
+        public void onLoadCompleted​(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+            segments.add(new Segment(mediaLoadData.mediaEndTimeMs, mediaLoadData.mediaStartTimeMs, loadEventInfo.uri));
+            removePassedSegments();
+        }
+
+        @Override
+        public void onLoadError​(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
+            eventEmitter.error("Failed loading a segment", error, "20001", loadEventInfo.uri.toString());
+            Log.e("ExoPlayer Exception", "Failed loading a segment" + error.toString());
+            segments.add(new Segment(mediaLoadData.mediaEndTimeMs, mediaLoadData.mediaStartTimeMs, loadEventInfo.uri));
+            removePassedSegments();
+        }
+    }
+
     private void startBufferCheckTimer() {
         Player player = this.player;
         VideoEventEmitter eventEmitter = this.eventEmitter;
@@ -543,7 +585,27 @@ class ReactExoplayerView extends FrameLayout implements
                 }
             }
         }, 1);
-        
+    }
+
+    private String getUriOfCurrentSegment() {
+        long currentPosition = player.getCurrentPosition();
+        for (int i = 0; i < segments.size(); i++) {
+            Segment segment = segments.get(i);
+            if (segment.mediaStartTimeMs < currentPosition && currentPosition < segment.mediaEndTimeMs) {
+                return segment.uri.toString();
+            }
+        }
+        return "";
+    }
+
+    private void removePassedSegments() {
+        long currentPosition = player.getCurrentPosition();
+        for (int i = 0; i < segments.size(); i++) {
+            Segment segment = segments.get(i);
+            if (segment.mediaEndTimeMs < currentPosition) {
+                segments.remove(i);
+            }
+        }
     }
 
     private void initializePlayerCore(ReactExoplayerView self) {
@@ -603,6 +665,9 @@ class ReactExoplayerView extends FrameLayout implements
     private void initializePlayerSource(ReactExoplayerView self, DrmSessionManager drmSessionManager) {
         ArrayList<MediaSource> mediaSourceList = buildTextSources();
         MediaSource videoSource = buildMediaSource(self.srcUri, self.extension, drmSessionManager);
+
+        videoSource.addEventListener​(this.mainHandler, this.mediaSourceEventListener);
+
         MediaSource mediaSource;
         if (mediaSourceList.size() == 0) {
             mediaSource = videoSource;
@@ -779,6 +844,7 @@ class ReactExoplayerView extends FrameLayout implements
             trackSelector = null;
             player = null;
         }
+        segments.clear();
         progressHandler.removeMessages(SHOW_PROGRESS);
         themedReactContext.removeLifecycleEventListener(this);
         audioBecomingNoisyReceiver.removeListener();
@@ -1300,7 +1366,7 @@ class ReactExoplayerView extends FrameLayout implements
             default:
                 break;
         }
-        eventEmitter.error(errorString, e, errorCode);
+        eventEmitter.error(errorString, e, errorCode, getUriOfCurrentSegment());
         playerNeedsSource = true;
         if (isBehindLiveWindow(e)) {
             clearResumePosition();
@@ -1801,6 +1867,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onDrmSessionManagerError(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, Exception e) {
+        // this method will be invoked if the http request for the license fails
         Log.d("DRM Info", "onDrmSessionManagerError");
         eventEmitter.error("onDrmSessionManagerError", e, "3002");
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -134,6 +134,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_ERROR_EXCEPTION = "errorException";
     private static final String EVENT_PROP_ERROR_TRACE = "errorStackTrace";
     private static final String EVENT_PROP_ERROR_CODE = "errorCode";
+    private static final String EVENT_PROP_ERROR_SEGMENT = "errorSegment";
 
     private static final String EVENT_PROP_TIMED_METADATA = "metadata";
 
@@ -247,14 +248,18 @@ class VideoEventEmitter {
     }
 
     void error(String errorString, Exception exception) {
-        _error(errorString, exception, "0001");
+        _error(errorString, exception, "0001", "");
     }
 
     void error(String errorString, Exception exception, String errorCode) {
-        _error(errorString, exception, errorCode);
+        _error(errorString, exception, errorCode, "");
     }
 
-    void _error(String errorString, Exception exception, String errorCode) {
+    void error(String errorString, Exception exception, String errorCode, String segmentUri) {
+        _error(errorString, exception, errorCode, segmentUri);
+    }
+
+    void _error(String errorString, Exception exception, String errorCode, String segmentUri) {
         // Prepare stack trace
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
@@ -266,6 +271,7 @@ class VideoEventEmitter {
         error.putString(EVENT_PROP_ERROR_EXCEPTION, exception.toString());
         error.putString(EVENT_PROP_ERROR_CODE, errorCode);
         error.putString(EVENT_PROP_ERROR_TRACE, stackTrace);
+        error.putString(EVENT_PROP_ERROR_SEGMENT, segmentUri);
         WritableMap event = Arguments.createMap();
         event.putMap(EVENT_PROP_ERROR, error);
         receiveEvent(EVENT_ERROR, event);


### PR DESCRIPTION
This PR adds data to the errors sent to NewRelic

Jira: VEX-7847

Velovity PR: https://github.com/crunchyroll/velocity/pull/2684

Updated error codes: https://wiki.tenkasu.net/pages/resumedraft.action?draftId=917440198&draftShareId=a92db640-f929-47ca-8242-1e2074d85d29&

New Relic error reporting: https://wiki.tenkasu.net/pages/resumedraft.action?draftId=1448882419&draftShareId=4f0388cf-66fa-4549-a90e-58fb63294977&

As previously coordinated, the NewRelic class in the client allows Velocity to send any additional objects in string format, taking advantage of that, we are adding additional information to help us diagnose potential issues with the content delivery or playback services.

### Reviews

- Major reviewer (domain expert): @jctorresM 
- Minor reviewer: @rogercrunchyroll 

### PR Checklist

- [/] Unit tests have been written
- [x] Documentation has been created and/or updated

### Testing instructions

#### Android mobile

Test harness: https://static.cx-staging.com/vilos-v2-qa/task/VEX-7847-surface-additional-data-on-errors/android-mobile/android-app-debug.apk

Client app: https://static.cx-staging.com/vilos-v2-qa/task/VEX-7847-surface-additional-data-on-errors/androidmobile-client/etp-android-debug.apk

##### Android mobile phone

```
1. execute yarn start-androidmobile-client --clean
2. play any video
3. confirm the video plays with no issues
```
