### PR TITLE
VEX-7950: Android: Crash on tablet when exiting the player

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -611,6 +611,10 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void removePassedSegments() {
+        if (player == null) {
+            // Cannot remove segment if player is already destroyed
+            return;
+        }
         long currentPosition = player.getCurrentPosition();
         for (int i = 0; i < segments.size(); i++) {
             Segment segment = segments.get(i);


### PR DESCRIPTION
This PR fixes crash when destroying player while seek is in progress.

Jira: VEX-7950

Velocity PR: https://github.com/crunchyroll/velocity/pull/2694

When exiting the player we remove all references, but if a seek was in progress it would crash when removing passed segments. To resolve this a null check was added to prevent accessing properties from player if it is null.

Reviews
Major reviewer (domain expert): @gabriel-rivero 
Minor reviewer: @rogercrunchyroll 

Android
1. Execute yarn start-androidmobile-client --clean
2. Play any video
3. Resume any video
4. Pause and quick rewind 10s multiple times
5. Right after rewinding press back
6. Do this multiple times since the repro rate is around 30%