### PR TITLE
VEX-8156: prevent crashes found in initial rollout

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -542,6 +542,10 @@ class ReactExoplayerView extends FrameLayout implements
     private void initializePlayer() {
         ReactExoplayerView self = this;
         Activity activity = themedReactContext.getCurrentActivity();
+        if (activity == null) {
+            // if there is no activity, the player is most likely getting destroyed, in that case we don't need to initialize it
+            return;
+        }
         // This ensures all props have been settled, to avoid async racing conditions.
         new Handler().postDelayed(new Runnable() {
             @Override
@@ -1219,8 +1223,12 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private int getScreenShortestSide(ThemedReactContext context) {
-        if (context == null) {
-            // No context so we fallback to max int
+        if (
+          context == null ||
+          context.getCurrentActivity() == null ||
+          context.getCurrentActivity().getWindowManager() == null
+        ) {
+            // No context, activity or window manager, we'll return the max int
             return 2147483647;
         }
         Display display = context.getCurrentActivity().getWindowManager().getDefaultDisplay();


### PR DESCRIPTION
This PR fixes 2 `react-native-video` crashes that were detected during the rollout

Jira: VEX-8156
Jira: VEX-8157

Velocity PR: https://github.com/crunchyroll/velocity/pull/2781

Both crashes happened because the Android activity was not available and there were unprotected chained calls assuming the activity was present, during testing it was determined the condition happened when the player was being destroyed and the reference was removed already

### Reviews

- Major reviewer (domain expert): @JulioTorresCR 
- Minor reviewer: @jacob-livingston 
- Optional minor reviewer: @armadilio3 

### PR Checklist

- [/] Unit tests have been written
- [/] Documentation has been created and/or updated

### Testing instructions

#### Android mobile

Test harness: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-8156-fix-rnv-crashes/android-mobile/android-app-debug.apk

Client app: https://static.cx-staging.com/vilos-v2-qa/bugfix/VEX-8156-fix-rnv-crashes/androidmobile-client/etp-android-debug.apk

##### Android mobile phone

```
1. yarn start-androidmobile-client --clean
2. play any video
3. exit the player
4. load any video
5. confirm there is no crash
```
