### PR TITLE
ETPAND-9766: Fix NullPointerException (ReactExoplayerView.videoLoaded)

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1313,7 +1313,10 @@ public class ReactExoplayerView extends FrameLayout implements
             Format videoFormat = player.getVideoFormat();
             int width = videoFormat != null ? videoFormat.width : 0;
             int height = videoFormat != null ? videoFormat.height : 0;
-            long bitrate = (videoFormat != null || videoFormat.bitrate == Format.NO_VALUE) ? 0 : videoFormat.bitrate;
+            long bitrate = 0L;
+            if (videoFormat != null) {
+                bitrate = videoFormat.bitrate == Format.NO_VALUE ? 0L : videoFormat.bitrate;
+            }
             String trackId = videoFormat != null ? videoFormat.id : "-1";
 
             if (isUriNativeSource(this.srcUri) && mReportBandwidth) {


### PR DESCRIPTION
Fixes null pointer exception when video format is null.