### PR TITLE
ETPAND-9785: Fix crash when video ends using a native source

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1133,6 +1133,10 @@ public class ReactExoplayerView extends FrameLayout implements
             switch (player.getPlaybackState()) {
                 case Player.STATE_IDLE:
                 case Player.STATE_ENDED:
+                    if (isUriNativeSource(this.srcUri)) {
+                        // Native source does not need to be initialized again
+                        break;
+                    }
                     initializePlayer();
                     break;
                 case Player.STATE_BUFFERING:


### PR DESCRIPTION
There was a crash happening internally within Exoplayer when a native source was used and the video ended. This was caused by the player calling init when the video ends which corresponded with the native source change so it caused a crash internally because the source was no longer available.