### PR TITLE
ETPAND-9775: Screen is black but the audio is heard

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1376,6 +1376,7 @@ public class ReactExoplayerView extends FrameLayout implements
                     playerControlView.show();
                 }
                 setKeepScreenOn(preventsDisplaySleepDuringVideoPlayback);
+                reLayout(exoPlayerView);
                 break;
             case Player.STATE_ENDED:
                 text += "ended";


### PR DESCRIPTION
Re-layout when player is ready to make sure that the layout is visible when playback starts.