### PR TITLE
ETPAND-9981: Don't retry 403 ExoPlayer HttpDataSourceExceptions

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
@@ -21,10 +21,10 @@ public final class ReactExoplayerLoadErrorHandlingPolicy extends DefaultLoadErro
   public long getRetryDelayMsFor(LoadErrorInfo loadErrorInfo) {
 
     if (loadErrorInfo.exception instanceof InvalidResponseCodeException) {
-      Log.w("RNV", "Invalid response code"!);
+      Log.w("RNV", "Invalid response code");
       if (((InvalidResponseCodeException)loadErrorInfo.exception).responseCode == 403) {
         Log.w("RNV", "Request returned 403 - stopping retry!");
-        return C.TIME_UNSET
+        return C.TIME_UNSET;
       }
     }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
@@ -19,7 +19,7 @@ public final class ReactExoplayerLoadErrorHandlingPolicy extends DefaultLoadErro
   public long getRetryDelayMsFor(LoadErrorInfo loadErrorInfo) {
     if (
       loadErrorInfo.exception instanceof HttpDataSourceException &&
-      !(loadErrorInfo.exception instanceof InvalidResponseCodeException && loadErrorInfo.exception.responseCode == 403)
+      !(loadErrorInfo.exception instanceof InvalidResponseCodeException && loadErrorInfo.exception.responseCode == 403) &&
       (loadErrorInfo.exception.getMessage() == "Unable to connect" || loadErrorInfo.exception.getMessage() == "Software caused connection abort")
     ) {
       // Capture the error we get when there is no network connectivity and keep retrying it

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
@@ -7,6 +7,8 @@ import com.google.android.exoplayer2.upstream.HttpDataSource.InvalidResponseCode
 import com.google.android.exoplayer2.upstream.LoadErrorHandlingPolicy.LoadErrorInfo;
 import com.google.android.exoplayer2.C;
 
+import android.util.Log;
+
 public final class ReactExoplayerLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolicy {
   private int minLoadRetryCount = Integer.MAX_VALUE;
 
@@ -17,9 +19,17 @@ public final class ReactExoplayerLoadErrorHandlingPolicy extends DefaultLoadErro
 
   @Override
   public long getRetryDelayMsFor(LoadErrorInfo loadErrorInfo) {
+
+    if (loadErrorInfo.exception instanceof InvalidResponseCodeException) {
+      Log.w("RNV", "Invalid response code"!);
+      if (((InvalidResponseCodeException)loadErrorInfo.exception).responseCode == 403) {
+        Log.w("RNV", "Request returned 403 - stopping retry!");
+        return C.TIME_UNSET
+      }
+    }
+
     if (
       loadErrorInfo.exception instanceof HttpDataSourceException &&
-      !(loadErrorInfo.exception instanceof InvalidResponseCodeException && ((InvalidResponseCodeException)loadErrorInfo.exception).responseCode == 403) &&
       (loadErrorInfo.exception.getMessage() == "Unable to connect" || loadErrorInfo.exception.getMessage() == "Software caused connection abort")
     ) {
       // Capture the error we get when there is no network connectivity and keep retrying it

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
@@ -3,6 +3,7 @@ package com.brentvatne.exoplayer;
 import java.io.IOException;
 import com.google.android.exoplayer2.upstream.DefaultLoadErrorHandlingPolicy;
 import com.google.android.exoplayer2.upstream.HttpDataSource.HttpDataSourceException;
+import com.google.android.exoplayer2.upstream.HttpDataSource.InvalidResponseCodeException;
 import com.google.android.exoplayer2.upstream.LoadErrorHandlingPolicy.LoadErrorInfo;
 import com.google.android.exoplayer2.C;
 
@@ -18,6 +19,7 @@ public final class ReactExoplayerLoadErrorHandlingPolicy extends DefaultLoadErro
   public long getRetryDelayMsFor(LoadErrorInfo loadErrorInfo) {
     if (
       loadErrorInfo.exception instanceof HttpDataSourceException &&
+      !(loadErrorInfo.exception instanceof InvalidResponseCodeException && loadErrorInfo.exception.responseCode == 403)
       (loadErrorInfo.exception.getMessage() == "Unable to connect" || loadErrorInfo.exception.getMessage() == "Software caused connection abort")
     ) {
       // Capture the error we get when there is no network connectivity and keep retrying it

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerLoadErrorHandlingPolicy.java
@@ -19,7 +19,7 @@ public final class ReactExoplayerLoadErrorHandlingPolicy extends DefaultLoadErro
   public long getRetryDelayMsFor(LoadErrorInfo loadErrorInfo) {
     if (
       loadErrorInfo.exception instanceof HttpDataSourceException &&
-      !(loadErrorInfo.exception instanceof InvalidResponseCodeException && loadErrorInfo.exception.responseCode == 403) &&
+      !(loadErrorInfo.exception instanceof InvalidResponseCodeException && ((InvalidResponseCodeException)loadErrorInfo.exception).responseCode == 403) &&
       (loadErrorInfo.exception.getMessage() == "Unable to connect" || loadErrorInfo.exception.getMessage() == "Software caused connection abort")
     ) {
       // Capture the error we get when there is no network connectivity and keep retrying it


### PR DESCRIPTION
Emit 403 segment errors immediately without retrying.