### PR TITLE
ETPAND-9757: There's no space between the "?" and the timeline for the CSAI ads on tablet

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -96,6 +96,7 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
             LayoutParams.MATCH_PARENT);
         adOverlayFrameLayout = new FrameLayout(getContext());
         adOverlayFrameLayout.setLayoutParams(adOverlayLayoutParams);
+        adOverlayFrameLayout.setPadding(0, 10, 0, 10);
 
         addViewInLayout(layout, 0, aspectRatioParams);
         addViewInLayout(adOverlayFrameLayout, 1, adOverlayLayoutParams);


### PR DESCRIPTION
Add padding to top and bottom of CSAI FrameLayout.